### PR TITLE
bugfix: correct pagination page on history back

### DIFF
--- a/src/components/SearchPage.vue
+++ b/src/components/SearchPage.vue
@@ -5,11 +5,11 @@
       <autocomplete v-on:submit="onSuggestion" />
     </div>
     <div class="py-4">
-      <search-filters v-on:remove-filter="search" v-on:submit-filter="search" />
+      <search-filters v-on:remove-filter="search(1)" v-on:submit-filter="search(1)" />
     </div>
     <div slot="footer">
       <b-button-group class="d-flex bg-white">
-        <b-button class="w-100" v-on:click="search()">Search</b-button>
+        <b-button class="w-100" v-on:click="search(1)">Search</b-button>
         <b-button class="w-100" v-on:click="reset">Clear</b-button>
       </b-button-group>
     </div>
@@ -129,7 +129,7 @@ export default {
       },
       set(val) {
         this.$store.commit('search/UPDATE_SEARCH_ORDER_BY', val);
-        this.search();
+        this.search(1);
       },
     },
     groupBy: {
@@ -138,7 +138,7 @@ export default {
       },
       set(val) {
         this.$store.commit('search/UPDATE_SEARCH_GROUP_BY', val);
-        this.search();
+        this.search(1);
       },
     },
     displayStyle: {
@@ -183,7 +183,7 @@ export default {
   methods: {
     onSuggestion(suggestion) {
       this.$store.commit('search/ADD_FILTER', FilterFactory.create(suggestion));
-      this.search();
+      this.search(1);
     },
     onInputPagination(page = 1) {
       this.search(page);
@@ -199,8 +199,12 @@ export default {
         },
       });
     },
-    search(page = 1) {
-      this.$store.dispatch('search/SEARCH', page);
+    search(page) {
+      if (page !== undefined) {
+        this.$store.commit('search/UPDATE_PAGINATION_CURRENT_PAGE', parseInt(page, 10));
+      }
+
+      this.$store.dispatch('search/SEARCH');
     },
     reset() {
       this.$store.commit('search/CLEAR');

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,6 +15,15 @@ export default new Router({
     {
       path: '/',
       name: 'home',
+      beforeEnter: (to, from, next) => {
+        next({
+          name: 'search',
+        });
+      },
+    },
+    {
+      path: '/search',
+      name: 'search',
       component: SearchPage,
     },
     {

--- a/src/store/Search.js
+++ b/src/store/Search.js
@@ -64,12 +64,8 @@ export default {
       state.paginationPerPage = parseInt(paginationPerPage, 10);
     },
     // pagination
-    UPDATE_PAGINATION_CURRENT_PAGE(state, payload) {
-      if (typeof payload.paginationCurrentPage === 'undefined') {
-        state.paginationCurrentPage = 1;
-      } else {
-        state.paginationCurrentPage = payload.paginationCurrentPage;
-      }
+    UPDATE_PAGINATION_CURRENT_PAGE(state, page) {
+      state.paginationCurrentPage = parseInt(page, 10);
     },
     UPDATE_PAGINATION_TOTAL_ROWS(state, payload) {
       state.paginationTotalRows = payload.paginationTotalRows;
@@ -140,11 +136,7 @@ export default {
         context.commit('ADD_FILTER', filter);
       }
     },
-    SEARCH(context, paginationCurrentPage = 1) {
-      context.commit('UPDATE_PAGINATION_CURRENT_PAGE', {
-        paginationCurrentPage,
-      });
-
+    SEARCH(context) {
       const search = new Promise(
         (resolve, reject) => {
           services.search.find({


### PR DESCRIPTION
fixed small bug where on returning to the search results page via the history back button the first page is loaded instead of the page number the visitor was on last. This is done by explicitly passing the correct page number to be loaded on calling the search() function