### PR TITLE
bugfix: missing `matches` in returned articles on search endpoint

### DIFF
--- a/src/store/Search.js
+++ b/src/store/Search.js
@@ -176,7 +176,7 @@ export default {
                   lastModifiedDate: bucket.last_modified_date,
                   lastModifiedTime: bucket.last_modified_time,
                 })) : [],
-                matches: result.matches.map(match => new Match(match)),
+                matches: result.matches ? result.matches.map(match => new Match(match)) : [],
                 newspaper: new Newspaper({
                   ...result.newspaper,
                   countArticles: result.newspaper.count_articles,


### PR DESCRIPTION
There was an issue where the api does not return `matches` for some results so the article object could not be created. This only happens when ordering search results by `DATE ASC`. This is fixed by adding an inline if condition to the creation of the object.