### PR TITLE
Feature/newspaper lines

### DIFF
--- a/src/components/NewspapersDetailPage.vue
+++ b/src/components/NewspapersDetailPage.vue
@@ -1,0 +1,120 @@
+<template lang="html">
+    <i-layout-section>
+
+      <div slot="header" class="border-bottom">
+        <b-navbar type="light" variant="light">
+          <section class='pt-2'>
+            <span class="label small-caps">{{$t('newspaper')}}</span>
+            <h3 class='mb-1'>
+              {{newspaper.name}}
+              ({{newspaper.startYear}} - {{newspaper.endYear}})</h3>
+            <p class='mb-0' v-if='genealogy || publication'>
+              <span v-if='genealogy'>{{ genealogy }}</span>
+              <span v-if='publication'>{{ publication }}</span>
+            </p>
+          </section>
+
+        </b-navbar>
+
+      </div>
+      <div class="p-4">
+        <b-row>
+          <b-col
+            sm="12" lg="3"
+            v-for="(issue, index) in issues"
+            class="mb-4">
+            <div class="border">
+              <div class="p-3 border-bottom">
+                {{issue.uid}}
+              </div>
+              <issue-viewer v-model="issues[index]" />
+            </div>
+          </b-col>
+        </b-row>
+      </div>
+      <div slot="footer" class="p-2 border-top">
+        <pagination
+          v-bind:perPage="limit"
+          v-bind:currentPage="page"
+          v-bind:totalRows="total"
+          v-on:change="onInputPagination"
+          v-bind:showDescription="true" />
+      </div>
+  </i-layout-section>
+</template>
+
+<script>
+import Newspaper from '@/models/Newspaper';
+import Pagination from './modules/Pagination';
+import IssueViewer from './modules/IssueViewer';
+
+
+export default {
+  data: () => ({
+    total: 0,
+    page: 1,
+    limit: 36,
+    issues: [],
+    newspaper: new Newspaper(),
+  }),
+  computed: {
+    genealogy: {
+      get() {
+        const noteGenealogy = this.newspaper.properties.find(d => d.name === 'noteGenealogy');
+        if (noteGenealogy) {
+          return noteGenealogy.newspapers_metadata.value;
+        }
+        return false;
+      },
+    },
+    publication: {
+      get() {
+        const notePublicationDates = this.newspaper.properties.find(d => d.name === 'notePublicationDates');
+        if (notePublicationDates) {
+          return notePublicationDates.newspapers_metadata.value;
+        }
+        return false;
+      },
+    },
+  },
+  methods: {
+    async onInputPagination(page) {
+      console.log('page', page);
+      this.issues = await this.getIssues({
+        page,
+      });
+    },
+    async getIssues({
+      page = 1,
+    } = {}) {
+      const response = await this.$store.dispatch('newspapers/LOAD_ISSUES', {
+        page,
+        limit: this.limit,
+        filters: [{
+          type: 'newspaper',
+          q: this.$route.params.newspaper_uid,
+          context: 'include',
+        }],
+      });
+      this.total = response.total;
+      return response.data;
+    },
+
+    async getNewspaper() {
+      return this.$store.dispatch('newspapers/LOAD_DETAIL', this.$route.params.newspaper_uid);
+    },
+  },
+  async mounted() {
+    // get newspaper data;
+    this.issues = await this.getIssues();
+    this.newspaper = await this.getNewspaper();
+  },
+  components: {
+    Pagination,
+    IssueViewer,
+  },
+};
+</script>
+
+<style lang="css">
+</style>

--- a/src/components/NewspapersDetailPage.vue
+++ b/src/components/NewspapersDetailPage.vue
@@ -79,7 +79,6 @@ export default {
   },
   methods: {
     async onInputPagination(page) {
-      console.log('page', page);
       this.issues = await this.getIssues({
         page,
       });

--- a/src/components/NewspapersExplorerPage.vue
+++ b/src/components/NewspapersExplorerPage.vue
@@ -1,0 +1,54 @@
+<template lang="html">
+  <i-layout-section>
+    <div slot="header">
+      <b-navbar  type="light" variant="light" class="border-bottom">
+        <section class='pt-2 pb-1'>
+          <span class="label small-caps">{{$t('summary')}}</span>
+          <h3 class='mb-1'>{{ $t('list_of_newspapers') }}</h3>
+        </section>
+      </b-navbar>
+    </div>
+    <div id="d3-small-multiples" class="border-bottom"></div>
+    <pre>{{ pagesTimeline }}</pre>
+  </i-layout-section>
+</template>
+<script>
+
+export default {
+  data: () => ({
+    pagesTimeline: {
+      name: '',
+      values: [],
+    },
+  }),
+  async mounted() {
+    // global timeline per year, with n. of pages, n. of empty pages, n.of corrupted pages.
+    this.pagesTimeline = await this.$store.dispatch('newspapers/LOAD_PAGES_TIMELINE');
+  },
+  components: {
+    // Tooltip,
+  },
+};
+</script>
+
+<style lang="scss">
+  #d3-small-multiples{
+    background-color: darkgrey;
+  }
+</style>
+
+<i18n>
+{
+  "en": {
+    "label_order": "Order By",
+    "list_of_newspapers": "Newspapers"
+  },
+  "nl": {
+    "label_order": "Sorteer Op",
+    "sort_asc": "Oplopend",
+    "sort_desc": "Aflopend",
+    "sort_date": "Datum",
+    "sort_alphabetical": "Alfabetisch"
+  }
+}
+</i18n>

--- a/src/components/NewspapersPage.vue
+++ b/src/components/NewspapersPage.vue
@@ -64,7 +64,6 @@ export default {
       },
       set(newspaper) {
         this.$store.commit('newspapers/UPDATE_DETAIL_NEWSPAPER', newspaper);
-        // this.$store.dispatch('newspapers/LOAD_NEWSPAPER_ISSUES');
       },
     },
     newspaperUid() {
@@ -75,7 +74,7 @@ export default {
     },
     query: {
       get() {
-        return ''; // this.$store.state.newspapers.list.query;
+        return '';
       },
       set(val) {
         this.$store.commit('newspapers/UPDATE_LIST_QUERY', val);
@@ -105,7 +104,6 @@ export default {
     },
     orderBy: {
       get() {
-        // return 'date';
         return this.$store.state.newspapers.list.orderBy;
       },
       set(val) {
@@ -125,17 +123,6 @@ export default {
     onInputPaginationList(page = 1) {
       this.loadList(page);
     },
-    // loadIssues(page) {
-    //   if (page !== undefined) {
-    //     this.$store.commit('newspapers/UPDATE_DETAIL_PAGINATION_CURRENT_PAGE',
-    //     parseInt(page, 10));
-    //   }
-    //
-    //   return this.$store.dispatch('newspapers/LOAD_NEWSPAPER_ISSUES');
-    // },
-    // onInputPaginationDetail(page = 1) {
-    //   this.loadIssues(page);
-    // },
   },
   mounted() {
     this.loadList().then((res) => {

--- a/src/components/NewspapersPage.vue
+++ b/src/components/NewspapersPage.vue
@@ -23,7 +23,7 @@
         <router-link
           class="px-3 py-2 d-block"
           v-bind:class="{active: n.uid === newspaperUid}"
-          v-bind:to="{name: 'newspapers', params: {newspaper_uid: n.uid}}">
+          v-bind:to="{name: 'newspaper', params: {newspaper_uid: n.uid}}">
           <strong>{{n.name}}</strong>
           <br>
           ({{n.startYear}} - {{n.endYear}})
@@ -38,61 +38,12 @@
           v-bind:showDescription="true" />
       </div>
     </i-layout-section>
-    <i-layout-section>
-      <div slot="header" class="border-bottom">
-        <b-navbar type="light" variant="light">
-          {{newspaper.name}}
-        </b-navbar>
-      </div>
-      <div class="p-4">
-        <b-row>
-          <b-col
-            sm="12" lg="6"
-            v-for="(issue, index) in issues"
-            class="mb-4">
-            <div class="border">
-              <div class="p-3 border-bottom">
-                {{issue.uid}}
-              </div>
-              <issue-viewer v-model="issues[index]" />
-            </div>
-          </b-col>
-        </b-row>
-      </div>
-      <div slot="footer" class="p-2 border-top">
-        <pagination
-          v-bind:perPage="paginationDetail.perPage"
-          v-bind:currentPage="paginationDetail.currentPage"
-          v-bind:totalRows="paginationDetail.totalRows"
-          v-on:change="onInputPaginationDetail"
-          v-bind:showDescription="true" />
-      </div>
-    </i-layout-section>
-    <i-layout-section width="250px" class="border-left">
-      <div slot="header" class="border-bottom">
-        <b-navbar type="light" variant="light" >
-          metadata
-        </b-navbar>
-      </div>
-      <div class="p-4 border-bottom">
-        <p>Year of first issue<br>{{newspaper.startYear}}</p>
-        <p>Year of last issue<br>{{newspaper.endYear}}</p>
-        <p>Years running<br>{{newspaper.deltaYear}}</p>
-
-        <p v-show="newspaper.countArticles">Articles<br>{{newspaper.countArticles}}</p>
-        <p v-show="newspaper.countIssues">Issues<br>{{newspaper.countIssues}}</p>
-        <p v-show="newspaper.countPages">Pages<br>{{newspaper.countPages}}</p>
-      </div>
-      <div class="p-4">
-        <p v-for="property in newspaper.properties">{{property.name}}<br>{{property.newspapers_metadata.value}}</p>
-      </div>
-    </i-layout-section>
+    <router-view></router-view>
   </i-layout>
 </template>
 
 <script>
 import Pagination from './modules/Pagination';
-import IssueViewer from './modules/IssueViewer';
 
 export default {
   data: () => ({
@@ -113,7 +64,7 @@ export default {
       },
       set(newspaper) {
         this.$store.commit('newspapers/UPDATE_DETAIL_NEWSPAPER', newspaper);
-        this.$store.dispatch('newspapers/LOAD_NEWSPAPER_ISSUES');
+        // this.$store.dispatch('newspapers/LOAD_NEWSPAPER_ISSUES');
       },
     },
     newspaperUid() {
@@ -124,7 +75,7 @@ export default {
     },
     query: {
       get() {
-        return this.$store.state.newspapers.list.query;
+        return ''; // this.$store.state.newspapers.list.query;
       },
       set(val) {
         this.$store.commit('newspapers/UPDATE_LIST_QUERY', val);
@@ -174,16 +125,17 @@ export default {
     onInputPaginationList(page = 1) {
       this.loadList(page);
     },
-    loadIssues(page) {
-      if (page !== undefined) {
-        this.$store.commit('newspapers/UPDATE_DETAIL_PAGINATION_CURRENT_PAGE', parseInt(page, 10));
-      }
-
-      return this.$store.dispatch('newspapers/LOAD_NEWSPAPER_ISSUES');
-    },
-    onInputPaginationDetail(page = 1) {
-      this.loadIssues(page);
-    },
+    // loadIssues(page) {
+    //   if (page !== undefined) {
+    //     this.$store.commit('newspapers/UPDATE_DETAIL_PAGINATION_CURRENT_PAGE',
+    //     parseInt(page, 10));
+    //   }
+    //
+    //   return this.$store.dispatch('newspapers/LOAD_NEWSPAPER_ISSUES');
+    // },
+    // onInputPaginationDetail(page = 1) {
+    //   this.loadIssues(page);
+    // },
   },
   mounted() {
     this.loadList().then((res) => {
@@ -199,7 +151,7 @@ export default {
   },
   components: {
     Pagination,
-    IssueViewer,
+
   },
   watch: {
     newspaperUid: {

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -9,7 +9,7 @@
             <router-link v-bind:to="{ name: 'home'}" exact-active-class="active" class="nav-link small-caps">{{$t("label_home")}}</router-link>
           </li>
           <li class="nav-item">
-            <router-link v-bind:to="{ name: 'newspapers'}" exact-active-class="active" class="nav-link small-caps">{{$t("label_newspapers")}}</router-link>
+            <router-link v-bind:to="{ name: 'newspapersExplorer'}" exact-active-class="active" class="nav-link small-caps">{{$t("label_newspapers")}}</router-link>
           </li>
           <li class="nav-item">
             <router-link v-bind:to="{ name: 'topicsExplorer'}" exact-active-class="active" class="nav-link small-caps">{{$t("label_topics")}}</router-link>

--- a/src/d3-modules/SmallMultiples.js
+++ b/src/d3-modules/SmallMultiples.js
@@ -1,0 +1,31 @@
+import * as d3 from 'd3';
+import EventEmitter from 'events';
+
+export default class SmallMultiples extends EventEmitter {
+  constructor({
+    element,
+    height = 200,
+  } = {}) {
+    super();
+    this.height = height;
+    this.multiples = [];
+
+    this.svg = d3.select(element).append('svg')
+      .attr('width', '100%')
+      .attr('height', height)
+      .attr('preserveAspectRatio', 'none');
+  }
+
+  addSmallMultiple(sm) {
+    this.multiples.push(sm);
+    this.svg.height = this.height * this.multiples.height;
+  }
+
+  draw(data) {
+    this.x.domain(d3.extent(data, d => d.t));
+    this.y.domain([0, d3.max(data, d => d.w)]);
+
+    // / subdivide in groups
+  }
+
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,6 +10,8 @@ import CollectionsExplorerPage from '../components/CollectionsExplorerPage';
 import CollectionDetailPage from '../components/CollectionDetailPage';
 import TestPage from '../components/TestPage';
 import NewspapersPage from '../components/NewspapersPage';
+import NewspapersExplorerPage from '../components/NewspapersExplorerPage';
+import NewspapersDetailPage from '../components/NewspapersDetailPage';
 import TopicsPage from '../components/TopicsPage';
 import TopicsExplorerPage from '../components/TopicsExplorerPage';
 import TopicDetailPage from '../components/TopicDetailPage';
@@ -94,12 +96,22 @@ const router = new Router({
     },
   },
   {
-    path: '/newspapers/:newspaper_uid?',
+    path: '/newspapers',
     component: NewspapersPage,
     name: 'newspapers',
     meta: {
       realm: 'newspapers',
     },
+    children: [{
+      path: '',
+      component: NewspapersExplorerPage,
+      name: 'newspapersExplorer',
+    },
+    {
+      path: ':newspaper_uid',
+      component: NewspapersDetailPage,
+      name: 'newspaper',
+    }],
   },
   {
     path: '/playground',

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -53,6 +53,7 @@ export const suggestions = app.service('suggestions');
 export const articles = app.service('articles');
 export const issues = app.service('issues');
 export const pages = app.service('pages');
+export const pagesTimelines = app.service('pages-timelines');
 export const search = app.service('search');
 export const newspapers = app.service('newspapers');
 export const collections = app.service('collections');

--- a/src/store/Newspapers.js
+++ b/src/store/Newspapers.js
@@ -95,27 +95,35 @@ export default {
         );
       });
     },
-    LOAD_NEWSPAPER_ISSUES(context) {
-      const query = {
-        filters: [{
-          type: 'newspaper',
-          q: context.state.detail.newspaper.uid,
-          context: 'include',
-        }],
-        limit: context.state.detail.pagination.perPage,
-        page: context.state.detail.pagination.currentPage,
-      };
+    LOAD_PAGES_TIMELINE() {
+      return new Promise((resolve, reject) => {
+        services.pagesTimelines.get('stats', {})
+          .then(res => resolve(res))
+          .catch(reject);
+      });
+    },
+    LOAD_DETAIL(context, newspaperUid) {
+      return new Promise((resolve, reject) => {
+        services.newspapers.get(newspaperUid, {})
+          .then(res => resolve(res))
+          .catch(reject);
+      });
+    },
+    LOAD_ISSUES(context, {
+      page = 1,
+      limit,
+      filters = [],
+    } = {}) {
       return new Promise((resolve, reject) => {
         services.issues.find({
-          query,
-        }).then(
-          (res) => {
-            context.commit('UPDATE_DETAIL_PAGINATION_TOTAL_ROWS', res.total);
-            context.commit('UPDATE_DETAIL_ISSUES', res.data);
-            resolve(res);
-          },
-          reject,
-        );
+          query: { filters, page, limit },
+        })
+        .then((res) => {
+          context.commit('UPDATE_DETAIL_PAGINATION_TOTAL_ROWS', res.total);
+          // context.commit('UPDATE_DETAIL_ISSUES', res.data);
+          resolve(res);
+        })
+        .catch(reject);
       });
     },
   },

--- a/src/store/Newspapers.js
+++ b/src/store/Newspapers.js
@@ -120,7 +120,6 @@ export default {
         })
         .then((res) => {
           context.commit('UPDATE_DETAIL_PAGINATION_TOTAL_ROWS', res.total);
-          // context.commit('UPDATE_DETAIL_ISSUES', res.data);
           resolve(res);
         })
         .catch(reject);


### PR DESCRIPTION
Added basic routing mechanism for newspaper titles page.
still to do: reset list on the left if we click to the /newspapers page
display remaining properties (in a separate tab? in a simple modal?