### PR TITLE
Fix/issue#289

### DIFF
--- a/src/components/IssuePage.vue
+++ b/src/components/IssuePage.vue
@@ -2,6 +2,7 @@
     <i-layout id="IssuePage">
       <i-layout-section width="300px" class="border-right">
         <table-of-contents
+          style="width:300px"
           v-bind:toc="toc"
           v-bind:pageUid="pageUid"
           v-bind:articleUid="articleUid"
@@ -31,6 +32,7 @@
       </i-layout-section>
       <i-layout-section width="120px" class="border-left">
         <thumbnail-slider
+          style="width:120px"
           v-bind:issue="issue"
           v-on:click="loadPage"
           v-bind:bounds="bounds"

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -50,7 +50,7 @@
                     v-if="showLess"
                     @click="showLess = false"
                     class="text-white border-white"
-                    size="sm">{{$t('show all')}}</b-button>
+                    size="sm">{{$t('show_all')}}</b-button>
                   <b-button
                     v-if="!showLess"
                     @click="showLess = true"
@@ -454,6 +454,7 @@ $clr-grey-800: #c6ccd2;
     "label_search": "Search",
     "label_newspapers": "Newspaper Titles",
     "label_topics": "Topics",
+    "show_all": "Show All",
     "join_slack_channel": "Join us on <b>Slack!</b>",
     "no-jobs-yet": "Here you will find notifications about your collections and your downloads."
   }

--- a/src/components/modules/TableOfContents.vue
+++ b/src/components/modules/TableOfContents.vue
@@ -78,9 +78,8 @@ export default {
 @import "impresso-theme/src/scss/variables.sass";
 
 #TableOfContents{
-  position: fixed;
-  width: 299px;
-  height: calc( 100% - 60px );
+  position: absolute;
+  height: 100%;
   overflow-x: hidden;
   overflow-y: scroll;
   scroll-behavior: smooth;

--- a/src/components/modules/TableOfContents.vue
+++ b/src/components/modules/TableOfContents.vue
@@ -42,11 +42,13 @@ export default {
       });
     },
     scrollToActiveArticle() {
-      const elm = this.$refs[`article-${this.articleUid}`][0];
-      const parent = this.$refs.TableOfContents;
-      if (parent.scrollTop > elm.offsetTop ||
-        (elm.offsetTop - parent.scrollTop) > parent.offsetHeight) {
-        parent.scrollTop = elm.offsetTop;
+      if (this.articleUid) {
+        const elm = this.$refs[`article-${this.articleUid}`][0];
+        const parent = this.$refs.TableOfContents;
+        if (parent.scrollTop > elm.offsetTop ||
+          (elm.offsetTop - parent.scrollTop) > parent.offsetHeight) {
+          parent.scrollTop = elm.offsetTop;
+        }
       }
     },
   },

--- a/src/components/modules/TableOfContents.vue
+++ b/src/components/modules/TableOfContents.vue
@@ -43,10 +43,10 @@ export default {
     },
     scrollToActiveArticle() {
       const elm = this.$refs[`article-${this.articleUid}`][0];
-      const parent = this.$refs.TableOfContents.parentNode;
+      const parent = this.$refs.TableOfContents;
       if (parent.scrollTop > elm.offsetTop ||
         (elm.offsetTop - parent.scrollTop) > parent.offsetHeight) {
-        parent.scrollTo({ top: elm.offsetTop, behavior: 'smooth' });
+        parent.scrollTop = elm.offsetTop;
       }
     },
   },
@@ -78,6 +78,13 @@ export default {
 @import "impresso-theme/src/scss/variables.sass";
 
 #TableOfContents{
+  position: fixed;
+  width: 299px;
+  height: calc( 100% - 60px );
+  overflow-x: hidden;
+  overflow-y: scroll;
+  scroll-behavior: smooth;
+
   .pagenumber {
     font-size: 1.4em;
     color: lighten($clr-primary, 75);
@@ -112,8 +119,8 @@ export default {
       }
       &.active{
         a {
-          background: lighten($clr-primary, 88);
-          font-weight: bold;
+          background: lighten($clr-accent-secondary, 15);
+          // font-weight: bold;
         }
       }
     }

--- a/src/components/modules/ThumbnailSlider.vue
+++ b/src/components/modules/ThumbnailSlider.vue
@@ -46,7 +46,7 @@ export default {
       const parent = this.$refs.thumbnailSlider;
       if (parent.scrollTop > elm.offsetTop ||
         ((elm.offsetTop + elm.offsetHeight) - parent.scrollTop) > parent.offsetHeight) {
-        parent.scrollTo({ top: elm.offsetTop, behavior: 'smooth' });
+        parent.scrollTop = elm.offsetTop;
       }
     },
   },
@@ -70,13 +70,13 @@ export default {
 
 <style lang="less">
 #thumbnail-slider {
-    height: 100%;
+    position: fixed;
+    scroll-behavior: smooth;
+    height: calc( 100% - 60px );
     overflow-x: hidden;
     overflow-y: auto;
     white-space: nowrap;
-    &::-webkit-scrollbar {
-        display: none;
-    }
+
     .tiles {
         width: 100%;
         position: relative;

--- a/src/components/modules/ThumbnailSlider.vue
+++ b/src/components/modules/ThumbnailSlider.vue
@@ -70,16 +70,15 @@ export default {
 
 <style lang="less">
 #thumbnail-slider {
-    position: fixed;
+    position: absolute;
+    height: 100%;
     scroll-behavior: smooth;
-    height: calc( 100% - 60px );
     overflow-x: hidden;
-    overflow-y: auto;
+    overflow-y: scroll;
     white-space: nowrap;
 
     .tiles {
         width: 100%;
-        position: relative;
         height: 100%;
         .tile {
             width: 100%;

--- a/src/components/modules/ThumbnailSlider.vue
+++ b/src/components/modules/ThumbnailSlider.vue
@@ -42,11 +42,13 @@ export default {
       this.$emit('click', page);
     },
     scrollToActivePage() {
-      const elm = this.$refs[`page-${this.page.uid}`][0];
-      const parent = this.$refs.thumbnailSlider;
-      if (parent.scrollTop > elm.offsetTop ||
-        ((elm.offsetTop + elm.offsetHeight) - parent.scrollTop) > parent.offsetHeight) {
-        parent.scrollTop = elm.offsetTop;
+      if (this.page.uid) {
+        const elm = this.$refs[`page-${this.page.uid}`][0];
+        const parent = this.$refs.thumbnailSlider;
+        if (parent.scrollTop > elm.offsetTop ||
+          ((elm.offsetTop + elm.offsetHeight) - parent.scrollTop) > parent.offsetHeight) {
+          parent.scrollTop = elm.offsetTop;
+        }
       }
     },
   },


### PR DESCRIPTION
from Milan:
Scrolling in the search pane is not possible when using Safari (on Mac). The screen jumps back to the top immediately. This makes it impossible to read the topics.