### PR TITLE
Article/add missing info #159

### DIFF
--- a/src/components/UserLoginPage.vue
+++ b/src/components/UserLoginPage.vue
@@ -63,7 +63,7 @@ export default {
         password: this.password,
       }).then(() => {
         this.$router.push({
-          path: this.$route.query.redirect || '/',
+          path: window.previousUrl || window.redirect || '/',
         });
       }, (err) => {
         this.error = this.$t(err.message);

--- a/src/components/modules/CollectionAddTo.vue
+++ b/src/components/modules/CollectionAddTo.vue
@@ -1,9 +1,14 @@
 <template lang="html">
   <b-dropdown
-      size="sm" variant="outline-secondary"
-      v-on:show="fetch"
-      v-bind:text="text">
-    <collection-add-to-list :item="item" :items="items" />
+    size="sm" variant="outline-secondary"
+    v-on:show="fetch"
+    v-bind:text="text">
+    <div v-if="!isLoggedIn()" class="p-2 bg-light">
+      <b-button size="sm" class="w-100" variant="outline-primary" v-bind:to="{ name: 'login'}">
+        {{$t("login")}}
+      </b-button>
+    </div>
+    <collection-add-to-list v-else :item="item" :items="items" />
   </b-dropdown>
 </template>
 
@@ -24,7 +29,13 @@ export default {
   },
   methods: {
     fetch() {
-      return this.$store.dispatch('collections/LOAD_COLLECTIONS');
+      if (this.isLoggedIn()) {
+        return this.$store.dispatch('collections/LOAD_COLLECTIONS');
+      }
+      return {};
+    },
+    isLoggedIn() {
+      return this.$store.state.user.userData;
     },
   },
 };

--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -79,7 +79,6 @@
                   </div>
                 <!-- {{searchResult}} -->
 
-
                 <b-button variant="outline-secondary" size="sm" class="my-2"
                   v-on:click="onClickArticleSuggestion(searchResult)">
                   View Article
@@ -90,19 +89,12 @@
                   <span class="label small-caps">{{ $t("common_topics") }}</span>:
                   <b-badge variant="none" class="p-0" v-for="(rel, i) in commonTopics(searchResult.topics)" v-bind:key="i">
                     <router-link class="" style="padding:1px 3px;" :to="{ name: 'topic', params: { 'topic_uid': rel.topicUid }}">
-                      {{ rel.topic.getHtmlExcerpt() }} ({{ $n(rel.relevance * 100) }} %)
+                      {{ rel.topic.getHtmlExcerpt() }} ({{ $n(searchResult.topics[searchResult.topics.findIndex(c => (c.topicUid === rel.topicUid))].relevance * 100) }}%)
                     </router-link> &mdash;
                   </b-badge>
                 </div>
                 <!-- common topics end -->
 
-                <!-- <div v-for="topic in searchResult.topics" class="">
-                  {{topic.topicUid}} ({{topic.relevance}})
-                </div> -->
-                <!-- <search-results-tiles-item
-                  v-on:click="onClickArticleSuggestion(searchResult)"
-                  v-model="articlesSuggestions[index]" /> -->
-                  <!-- <pre>{{searchResult}}</pre> -->
                 </div>
               </b-col>
           </b-row>

--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -58,7 +58,6 @@
                 sm="12"
                 md="12"
                 lg="6"
-                style="min-height:200px; overflow:hidden"
                 v-for="(searchResult, index) in articlesSuggestions"
                 v-bind:key="searchResult.article_uid">
                 <div class="display-block w-100 h-100 border-top pt-2 my-2">
@@ -79,14 +78,29 @@
                   </div>
                 <!-- {{searchResult}} -->
 
-                <b-button variant="outline-secondary" size="sm" class="my-2"
+                <b-button variant="outline-secondary" size="sm"
                   v-on:click="onClickArticleSuggestion(searchResult)">
-                  View Article
+                  {{$t('view')}}
                 </b-button>
+
+                <!-- collections -->
+                <collection-add-to :item="searchResult" :text="$t('add_to_collection')" />
+                <b-badge
+                  v-for="(collection, i) in searchResult.collections"
+                  v-bind:key="i"
+                  variant="info"
+                  class="mt-1 mr-1">
+                  <router-link
+                    class="text-white"
+                    v-bind:to="{name: 'collection', params: {collection_uid: collection.uid}}">
+                    {{ collection.name }}
+                  </router-link>
+                  <a class="dripicons dripicons-cross" v-on:click="onRemoveCollection(collection, searchResult)" />
+                </b-badge>
 
                 <!-- common topics start -->
                 <div>
-                  <span class="label small-caps">{{ $t("common_topics") }}</span>:
+                  <div class="label small-caps mt-3">{{ $t("common_topics") }}</div>
                   <b-badge variant="none" class="p-0" v-for="(rel, i) in commonTopics(searchResult.topics)" v-bind:key="i">
                     <router-link class="" style="padding:1px 3px;" :to="{ name: 'topic', params: { 'topic_uid': rel.topicUid }}">
                       {{ rel.topic.getHtmlExcerpt() }} ({{ $n(searchResult.topics[searchResult.topics.findIndex(c => (c.topicUid === rel.topicUid))].relevance * 100) }}%)

--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -50,7 +50,7 @@
           </div>
         </div>
         <hr>
-        <b-container fluid>
+        <b-container fluid class="px-2">
           <h3>Similar Articles</h3>
           <b-row class="pb-5">
               <b-col
@@ -62,11 +62,28 @@
                 v-for="(searchResult, index) in articlesSuggestions"
                 v-bind:key="searchResult.article_uid">
                 <div class="display-block w-100 h-100 border-top pt-2 my-2">
+                  <div class="small-caps mb-1 float-left w-100">
+                    <router-link style="opacity:0.7" :to="{ name: 'issue', params: { issue_uid: searchResult.issue.uid }}">
+                      <div style="float:left; max-width:60%; text-overflow:ellipsis; overflow:hidden; white-space: nowrap;">
+                        {{ searchResult.newspaper.name}}
+                      </div>
+                      <div style="float:right; max-width: 40%; white-space: nowrap; text-overflow:ellipsis; overflow:hidden;">
+                         &mdash; {{$d(new Date(searchResult.date), 'compact')}}
+                      </div>
+                    </router-link>
+                  </div>
+
                   <div class="mb-2">
                     <b v-html="searchResult.title" />
                     <small v-html="searchResult.excerpt" />
                   </div>
                 <!-- {{searchResult}} -->
+
+
+                <b-button variant="outline-secondary" size="sm" class="my-2"
+                  v-on:click="onClickArticleSuggestion(searchResult)">
+                  View Article
+                </b-button>
 
                 <!-- common topics start -->
                 <div>
@@ -78,11 +95,6 @@
                   </b-badge>
                 </div>
                 <!-- common topics end -->
-
-                <b-button variant="outline-secondary" size="sm" class="mt-2"
-                  v-on:click="onClickArticleSuggestion(searchResult)">
-                  View Article
-                </b-button>
 
                 <!-- <div v-for="topic in searchResult.topics" class="">
                   {{topic.topicUid}} ({{topic.relevance}})

--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -53,17 +53,46 @@
         <b-container fluid>
           <h3>Similar Articles</h3>
           <b-row class="pb-5">
-            <b-col
-              cols="6"
-              sm="12"
-              md="6"
-              lg="4"
-              v-for="(searchResult, index) in articlesSuggestions"
-              v-bind:key="searchResult.article_uid">
-              <search-results-tiles-item
-                v-on:click="onClickArticleSuggestion(searchResult)"
-                v-model="articlesSuggestions[index]" />
-            </b-col>
+              <b-col
+                cols="12"
+                sm="12"
+                md="12"
+                lg="6"
+                style="min-height:200px; overflow:hidden"
+                v-for="(searchResult, index) in articlesSuggestions"
+                v-bind:key="searchResult.article_uid">
+                <div class="display-block w-100 h-100 border-top pt-2 my-2">
+                  <div class="mb-2">
+                    <b v-html="searchResult.title" />
+                    <small v-html="searchResult.excerpt" />
+                  </div>
+                <!-- {{searchResult}} -->
+
+                <!-- common topics start -->
+                <div>
+                  <span class="label small-caps">{{ $t("common_topics") }}</span>:
+                  <b-badge variant="none" class="p-0" v-for="(rel, i) in commonTopics(searchResult.topics)" v-bind:key="i">
+                    <router-link class="" style="padding:1px 3px;" :to="{ name: 'topic', params: { 'topic_uid': rel.topicUid }}">
+                      {{ rel.topic.getHtmlExcerpt() }} ({{ $n(rel.relevance * 100) }} %)
+                    </router-link> &mdash;
+                  </b-badge>
+                </div>
+                <!-- common topics end -->
+
+                <b-button variant="outline-secondary" size="sm" class="mt-2"
+                  v-on:click="onClickArticleSuggestion(searchResult)">
+                  View Article
+                </b-button>
+
+                <!-- <div v-for="topic in searchResult.topics" class="">
+                  {{topic.topicUid}} ({{topic.relevance}})
+                </div> -->
+                <!-- <search-results-tiles-item
+                  v-on:click="onClickArticleSuggestion(searchResult)"
+                  v-model="articlesSuggestions[index]" /> -->
+                  <!-- <pre>{{searchResult}}</pre> -->
+                </div>
+              </b-col>
           </b-row>
         </b-container>
       </i-layout-section>
@@ -111,6 +140,16 @@ export default {
     SearchResultsTilesItem,
   },
   methods: {
+    commonTopics(suggestionTopics) {
+      // console.log(t);
+      // console.log(this.topics);
+      const intersection =
+        this.topics.filter(a => suggestionTopics.some(b => a.topicUid === b.topicUid));
+
+      // const common = arrA.filter(x => (arrB.includes(el)));
+      // console.log(intersection);
+      return intersection;
+    },
     onRemoveCollection(collection, item) {
       const idx = item.collections.findIndex(c => (c.uid === collection.uid));
       if (idx !== -1) {
@@ -176,7 +215,8 @@ export default {
   "en": {
     "page": "pag. {num}",
     "pages": "pp. {nums}",
-    "add_to_collection": "Add to Collection ..."
+    "add_to_collection": "Add to Collection ...",
+    "common_topics": "Topics in common"
   }
 }
 </i18n>

--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -24,9 +24,12 @@
         </b-badge>
         <div class="my-3">
           <span class="label small-caps">{{ $t("topics")}}</span>:
-          <span v-for="(rel, i) in topics" v-bind:key="i">
-            <router-link :to="{ name: 'topic', params: { 'topic_uid': rel.topic.uid }}">
-              {{ rel.topic.getHtmlExcerpt() }} ({{ $n(rel.relevance * 100) }} %)
+          <span v-for="(rel, i) in topics" v-bind:key="i" class="position-relative">
+            <div class="bg-accent-secondary position-absolute"
+              :style="`width:${$n(rel.relevance * 100 * 4)}px;
+              top:3px; left:0; height:1em; z-index:-1`" />
+            <router-link :to="{ name: 'topic', params: { 'topic_uid': rel.topic.uid }}" class="small">
+              {{ rel.topic.getHtmlExcerpt() }} <span class="text-muted">({{ $n(rel.relevance * 100) }} %)</span>
             </router-link> &mdash;
           </span>
         </div>
@@ -50,7 +53,7 @@
           </div>
         </div>
         <hr>
-        <b-container fluid class="px-2">
+        <b-container fluid class="px-0">
           <h3>Similar Articles</h3>
           <b-row class="pb-5">
               <b-col
@@ -143,7 +146,7 @@ export default {
 };
 </script>
 
-<style lang="less">
+<style lang="scss">
 #IssueViewerText{
   overflow: none;
   height: 100%;

--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -12,7 +12,7 @@
         <collection-add-to :item="article" :text="$t('add_to_collection')" />
         <b-badge
           v-for="(collection, i) in article.collections"
-          v-bind:key="i"
+          v-bind:key="`co_${i}`"
           variant="info"
           class="mt-1 mr-1">
           <router-link
@@ -59,7 +59,9 @@
                 md="12"
                 lg="6"
                 v-for="(searchResult, index) in articlesSuggestions"
-                v-bind:key="searchResult.article_uid">
+                v-bind:key="`${index}_ra`">
+
+                <!-- newspaper - issue date -->
                 <div class="display-block w-100 h-100 border-top pt-2 my-2">
                   <div class="small-caps mb-1 float-left w-100">
                     <router-link style="opacity:0.7" :to="{ name: 'issue', params: { issue_uid: searchResult.issue.uid }}">
@@ -75,8 +77,8 @@
                   <div class="mb-2">
                     <b v-html="searchResult.title" />
                     <small v-html="searchResult.excerpt" />
+                    <!-- <pre class="small">{{searchResult}}</pre> -->
                   </div>
-                <!-- {{searchResult}} -->
 
                 <b-button variant="outline-secondary" size="sm"
                   v-on:click="onClickArticleSuggestion(searchResult)">
@@ -87,7 +89,7 @@
                 <collection-add-to :item="searchResult" :text="$t('add_to_collection')" />
                 <b-badge
                   v-for="(collection, i) in searchResult.collections"
-                  v-bind:key="i"
+                  v-bind:key="`${searchResult.article_uid}_co${i}`"
                   variant="info"
                   class="mt-1 mr-1">
                   <router-link
@@ -101,7 +103,9 @@
                 <!-- common topics start -->
                 <div>
                   <div class="label small-caps mt-3">{{ $t("common_topics") }}</div>
-                  <b-badge variant="none" class="p-0" v-for="(rel, i) in commonTopics(searchResult.topics)" v-bind:key="i">
+                  <b-badge variant="none" class="p-0"
+                    v-for="(rel, i) in commonTopics(searchResult.topics)"
+                    v-bind:key="`${searchResult.article_uid}_ct${i}`">
                     <router-link class="" style="padding:1px 3px;" :to="{ name: 'topic', params: { 'topic_uid': rel.topicUid }}">
                       {{ rel.topic.getHtmlExcerpt() }} ({{ $n(searchResult.topics[searchResult.topics.findIndex(c => (c.topicUid === rel.topicUid))].relevance * 100) }}%)
                     </router-link> &mdash;

--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -116,6 +116,8 @@ export default {
   methods: {
     commonTopics(suggestionTopics) {
       return this.topics.filter(a => suggestionTopics.some(b => a.topicUid === b.topicUid));
+      // sort by master topics relevance
+      // .sort((a, b) => b.relevance - a.relevance);
     },
     onRemoveCollection(collection, item) {
       const idx = item.collections.findIndex(c => (c.uid === collection.uid));

--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -26,7 +26,7 @@
           <span class="label small-caps">{{ $t("topics")}}</span>:
           <span v-for="(rel, i) in topics" v-bind:key="i" class="position-relative">
             <div class="bg-accent-secondary position-absolute"
-              :style="`width:${$n(rel.relevance * 100 * 4)}px;
+              :style="`width:${$n(rel.relevance * 100 * 2)}px;
               top:3px; left:0; height:1em; z-index:-1`" />
             <router-link :to="{ name: 'topic', params: { 'topic_uid': rel.topic.uid }}" class="small">
               {{ rel.topic.getHtmlExcerpt() }} <span class="text-muted">({{ $n(rel.relevance * 100) }} %)</span>

--- a/src/components/modules/SearchResultsListItem.vue
+++ b/src/components/modules/SearchResultsListItem.vue
@@ -62,7 +62,6 @@
         </router-link>
 
         <collection-add-to
-          v-if="isLoggedIn()"
           v-bind:item="article"
           v-bind:text="$t('add_to_collection')" />
       </div>

--- a/src/components/modules/SearchResultsSimilarItem.vue
+++ b/src/components/modules/SearchResultsSimilarItem.vue
@@ -1,0 +1,110 @@
+<template lang="html">
+  <!-- newspaper - issue date -->
+  <div class="display-block w-100 h-100 border-top pt-2 my-2">
+    <div class="small-caps mb-1 float-left w-100">
+      <router-link style="opacity:0.7" :to="{ name: 'issue', params: { issue_uid: searchResult.issue.uid }}">
+        <div style="float:left; max-width:60%; text-overflow:ellipsis; overflow:hidden; white-space: nowrap;">
+          {{ searchResult.newspaper.name}}
+        </div>
+        <div style="float:right; max-width: 40%; white-space: nowrap; text-overflow:ellipsis; overflow:hidden;">
+           &mdash; {{$d(new Date(searchResult.date), 'compact')}}
+        </div>
+      </router-link>
+    </div>
+
+    <div class="mb-2">
+      <b v-html="searchResult.title" />
+      <small v-html="searchResult.excerpt" />
+      <!-- <pre class="small">{{searchResult}}</pre> -->
+    </div>
+
+    <b-button variant="outline-secondary" size="sm"
+      v-on:click="onClickArticleSuggestion(searchResult)">
+      {{$t('view')}}
+    </b-button>
+
+    <!-- collections -->
+    <collection-add-to :item="searchResult" :text="$t('add_to_collection')" />
+    <div class="mt-1" />
+    <b-badge
+      v-for="(collection, i) in searchResult.collections"
+      v-bind:key="`${searchResult.article_uid}_co${i}`"
+      variant="info"
+      class="mt-1 mr-1">
+      <router-link
+        class="text-white"
+        v-bind:to="{name: 'collection', params: {collection_uid: collection.uid}}">
+        {{ collection.name }}
+      </router-link>
+      <!-- <a class="dripicons dripicons-cross" v-on:click="onRemoveCollection(collection, searchResult)" /> -->
+    </b-badge>
+
+    <!-- {{topics}} -->
+    <!-- common topics start -->
+    <div v-if="topics.length > 0">
+      <div class="label small-caps mt-3">{{ $t("common_topics") }}</div>
+      <div
+        v-for="(rel, i) in topics"
+        class="position-relative"
+        v-bind:key="`${searchResult.article_uid}_ct${i}`">
+        <div class="bg-accent-secondary position-absolute"
+          :style="`width:${$n(searchResult.topics[topics.findIndex(c => (c.topicUid === rel.topicUid))].relevance * 100)}%;
+          height:100%; top:3px; left:0; border-bottom:5px solid white; z-index:-1`" />
+        <b-badge variant="none" class="p-0"
+          <router-link class="small" style="padding:1px 3px;" :to="{ name: 'topic', params: { 'topic_uid': rel.topicUid }}">
+            {{ rel.topic.getHtmlExcerpt() }}
+            <span class="text-muted">({{ $n(searchResult.topics[
+              topics.findIndex(c => (c.topicUid === rel.topicUid))].relevance * 100) }}%)</span>
+          </router-link>
+        </b-badge>
+      </div>
+    </div>
+
+  </div>
+
+</template>
+
+<script>
+// import Article from '@/models/Article';
+import CollectionAddTo from './CollectionAddTo';
+
+export default {
+  // data() {
+  //   return {
+  //     article: new Article(),
+  //   };
+  // },
+  model: {
+    prop: 'article',
+  },
+  props: ['searchResult', 'topics'],
+  components: {
+    CollectionAddTo,
+  },
+  methods: {
+    onClickArticleSuggestion(searchResult) {
+      this.$router.push({
+        name: 'article',
+        params: {
+          issue_uid: searchResult.issue.uid,
+          page_number: searchResult.pages[0].num,
+          page_uid: searchResult.pages[0].uid,
+          article_uid: searchResult.uid,
+        },
+      });
+    },
+    isLoggedIn() {
+      return this.$store.state.user.userData;
+    },
+  },
+};
+</script>
+
+<i18n>
+{
+  "en": {
+    "add_to_collection": "Add to Collection ...",
+    "common_topics": "Topics in common"
+  }
+}
+</i18n>

--- a/src/components/modules/SearchResultsSimilarItem.vue
+++ b/src/components/modules/SearchResultsSimilarItem.vue
@@ -36,10 +36,8 @@
         v-bind:to="{name: 'collection', params: {collection_uid: collection.uid}}">
         {{ collection.name }}
       </router-link>
-      <!-- <a class="dripicons dripicons-cross" v-on:click="onRemoveCollection(collection, searchResult)" /> -->
     </b-badge>
 
-    <!-- {{topics}} -->
     <!-- common topics start -->
     <div v-if="topics.length > 0">
       <div class="label small-caps mt-3">{{ $t("common_topics") }}</div>

--- a/src/components/modules/SearchResultsSimilarItem.vue
+++ b/src/components/modules/SearchResultsSimilarItem.vue
@@ -1,8 +1,8 @@
 <template lang="html">
   <!-- newspaper - issue date -->
-  <div class="display-block w-100 h-100 border-top pt-2 my-2">
-    <div class="small-caps mb-1 float-left w-100">
-      <router-link style="opacity:0.7" :to="{ name: 'issue', params: { issue_uid: searchResult.issue.uid }}">
+  <div class="similar-item display-block w-100 h-100 border-top my-2 p-1">
+    <div class="small-caps mb-0 float-left w-100">
+      <router-link class="text-muted" :to="{ name: 'issue', params: { issue_uid: searchResult.issue.uid }}">
         <div style="float:left; max-width:60%; text-overflow:ellipsis; overflow:hidden; white-space: nowrap;">
           {{ searchResult.newspaper.name}}
         </div>
@@ -18,13 +18,13 @@
       <!-- <pre class="small">{{searchResult}}</pre> -->
     </div>
 
-    <b-button variant="outline-secondary" size="sm"
+    <b-button variant="outline-secondary" size="sm" class="showOnHover"
       v-on:click="onClickArticleSuggestion(searchResult)">
       {{$t('view')}}
     </b-button>
 
     <!-- collections -->
-    <collection-add-to :item="searchResult" :text="$t('add_to_collection')" />
+    <collection-add-to :item="searchResult" :text="$t('add_to_collection')" class="showOnHover" />
     <div class="mt-1" />
     <b-badge
       v-for="(collection, i) in searchResult.collections"
@@ -49,8 +49,8 @@
         v-bind:key="`${searchResult.article_uid}_ct${i}`">
         <div class="bg-accent-secondary position-absolute"
           :style="`width:${$n(searchResult.topics[topics.findIndex(c => (c.topicUid === rel.topicUid))].relevance * 100)}%;
-          height:100%; top:3px; left:0; border-bottom:5px solid white; z-index:-1`" />
-        <b-badge variant="none" class="p-0"
+          height:100%; top:3px; height:calc( 100% - 5px); z-index:-1`" />
+        <b-badge variant="none" class="p-0 showOnHover position-absolute"
           <router-link class="small" style="padding:1px 3px;" :to="{ name: 'topic', params: { 'topic_uid': rel.topicUid }}">
             {{ rel.topic.getHtmlExcerpt() }}
             <span class="text-muted">({{ $n(searchResult.topics[
@@ -93,12 +93,28 @@ export default {
         },
       });
     },
-    isLoggedIn() {
-      return this.$store.state.user.userData;
-    },
   },
 };
 </script>
+
+<style lang="scss">
+@import "impresso-theme/src/scss/variables.sass";
+
+.similar-item {
+  transition: background-color 0.2s;
+  background-color: rgba(0,0,0,0);
+  .showOnHover {
+    transition: opacity 0.2s;
+    opacity: 0;
+  }
+}
+.similar-item:hover {
+  background-color: rgba(0,0,0,0.04);
+  .showOnHover {
+    opacity: 1;
+  }
+}
+</style>
 
 <i18n>
 {

--- a/src/components/modules/TableOfContents.vue
+++ b/src/components/modules/TableOfContents.vue
@@ -38,21 +38,15 @@
             <div v-if="article.collections && article.collections.length > 0" class="article-collections mb-2">
               <b-badge
                 v-for="(collection, i) in article.collections"
-                v-bind:key="i"
+                v-bind:key="`${article.article_uid}_col${i}`"
                 variant="info"
-                class="mr-1">
-                <router-link
-                  class="text-white"
-                  v-bind:to="{name: 'collection', params: {collection_uid: collection.uid}}">
+                class="mt-1 mr-1">
                   {{ collection.name }}
-                </router-link>
-                <a class="dripicons dripicons-cross" v-on:click="onRemoveCollection(collection, article)" />
               </b-badge>
             </div>
 
             <collection-add-to
             class="mt-2"
-              v-if="isLoggedIn()"
               v-bind:item="article"
               v-bind:text="$t('add_to_collection')" />
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -67,9 +67,13 @@ const router = new Router({
     path: '/user/logout',
     name: 'logout',
     component: UserLoginPage,
-    beforeEnter: (to, from, next) => {
+    beforeEnter: () => {
       store.dispatch('user/LOGOUT').then(() => {
-        next();
+        this.$router.push({
+          path: this.$route.query.redirect || '/',
+        });
+      }, (err) => {
+        this.error = this.$t(err.message);
       });
     },
     meta: {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -239,6 +239,7 @@ const router = new Router({
 });
 
 router.beforeEach((to, from, next) => {
+  window.previousUrl = from.path;
   if (to.meta.requiresAuth === false) {
     next();
   } else {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -239,7 +239,6 @@ const router = new Router({
 });
 
 router.beforeEach((to, from, next) => {
-  window.previousUrl = from.path;
   if (to.meta.requiresAuth === false) {
     next();
   } else {
@@ -250,7 +249,7 @@ router.beforeEach((to, from, next) => {
         next({
           name: 'login',
           query: {
-            redirect: to.path,
+            redirect: from.path,
           },
         });
       }


### PR DESCRIPTION
Similar ("recommended") articles issue #159 
- replaced searchItemTilesItem by lighter component: `<search-results-similar-items>`
- added common topics (intersection between article and suggestion topics)
- added topic relevance visualizations
- added collection tagging