### PR TITLE
Fix/159

### DIFF
--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -2,52 +2,56 @@
   <div id="IssueViewerText" class="container-fluid py-3 bg-light">
     <i-layout>
       <i-layout-section>
-        <i-spinner v-if="!article.uid" class="text-center p-5" />
-        <article-item :item="article" :show-entities="true" :show-topics="true"/>
-        <div class="my-2" />
-        <collection-add-to :item="article" :text="$t('add_to_collection')" />
-        <b-badge
-          v-for="(collection, i) in article.collections"
-          v-bind:key="`co_${i}`"
-          variant="info"
-          class="mt-1 mr-1">
-          <router-link
-            class="text-white"
-            v-bind:to="{name: 'collection', params: {collection_uid: collection.uid}}">
-            {{ collection.name }}
-          </router-link>
-          <a class="dripicons dripicons-cross" v-on:click="onRemoveCollection(collection, article)" />
-        </b-badge>
-        <div class="alert alert-light" role="alert" v-if="!article.isCC">
-          <p>{{ $t('wrongLayout') }} <icon name="image"/></p>
-        </div>
-        <div v-if="hasValidRegions === false">
-          <p>{{article.excerpt}}</p>
-        </div>
-        <div
-          v-else
-          class="region-row mt-3 mb-3 bg-white">
-          <div class="row" v-for="(region, i) in article.regions" v-bind:key="i">
-            <div
-              class="col"
-              :class="{ 'col-sm-7': article.isCC, 'col-sm-12': !article.isCC }">
-              <div class='region py-3'>
-                <!-- {{ i }} -->
-                <p v-for="contents in region.g" >
-                  <span v-html="contents"></span>
-                </p>
-              </div>
-            </div>
-            <div v-if="article.isCC" class="col  bg-white p-0">
-              <img v-bind:src="region.iiifFragment" width="100%" />
-            </div>
+        <i-spinner v-if="!article" class="text-center p-5" />
+        <div v-if="article">
+          <article-item :item="article" show-entities show-excerpt show-meta show-topics/>
+          <div class="my-2" />
+          <collection-add-to :item="article" :text="$t('add_to_collection')" />
+          <b-badge
+            v-for="(collection, i) in article.collections"
+            v-bind:key="`co_${i}`"
+            variant="info"
+            class="mt-1 mr-1">
+            <router-link
+              class="text-white"
+              v-bind:to="{name: 'collection', params: {collection_uid: collection.uid}}">
+              {{ collection.name }}
+            </router-link>
+            <a class="dripicons dripicons-cross" v-on:click="onRemoveCollection(collection, article)" />
+          </b-badge>
+          <div class="alert alert-light" role="alert" v-if="!article.isCC">
+            <p>{{ $t('wrongLayout') }} <icon name="image"/></p>
           </div>
+          <div v-if="hasValidRegions === false">
+            <p>{{article.excerpt}}</p>
+          </div>
+          <b-container fluid
+            v-else
+            class="region-row mt-3 mb-3 bg-white">
+            <b-row v-for="(region, i) in article.regions" v-bind:key="i">
+              <div
+                class="col"
+                :class="{ 'col-sm-7': article.isCC, 'col-sm-12': !article.isCC }">
+                <div class='region py-3'>
+                  <!-- {{ i }} -->
+                  <p v-for="contents in region.g" >
+                    <span v-html="contents"></span>
+                  </p>
+                </div>
+              </div>
+              <div v-if="article.isCC" class="col col-sm-5 bg-white">
+                <div >
+                  <img v-bind:src="region.iiifFragment" style="width: 100%" />
+                </div>
+              </div>
+            </b-row>
+          </b-container>
         </div>
         <hr class="py-4">
         <b-container fluid class="px-0">
           <h3>Similar Articles</h3>
-          <i-spinner v-if="articlesSuggestions.length === 0" class="text-center p-5" />
-          <b-row class="pb-5">
+          <i-spinner v-if="!articlesSuggestions.length" class="text-center p-5" />
+          <b-row>
             <b-col
               cols="12"
               sm="12"
@@ -69,7 +73,6 @@
 <script>
 import Icon from 'vue-awesome/components/Icon';
 import { articlesSuggestions } from '@/services';
-import Article from '@/models/Article';
 import BaseTitleBar from './../base/BaseTitleBar';
 import CollectionAddTo from './CollectionAddTo';
 import SearchResultsSimilarItem from './SearchResultsSimilarItem';
@@ -79,7 +82,7 @@ import ArticleItem from './lists/ArticleItem';
 export default {
   data() {
     return {
-      article: new Article(),
+      article: null,
       articlesSuggestions: [],
     };
   },
@@ -132,9 +135,8 @@ export default {
     article_uid: {
       immediate: true,
       async handler(articleUid) {
-        this.article = new Article();
         this.articlesSuggestions = [];
-        this.article = await this.$store.dispatch('articles/LOAD_ARTICLE', articleUid).then();
+        this.article = await this.$store.dispatch('articles/LOAD_ARTICLE', articleUid);
         articlesSuggestions.get(articleUid).then((res) => {
           this.articlesSuggestions = res.data;
         });

--- a/src/components/modules/SearchResultsListItem.vue
+++ b/src/components/modules/SearchResultsListItem.vue
@@ -9,14 +9,7 @@
 
       <div class="list-item-details">
         <!-- if article -->
-        <article-item :item="article" v-bind:show-excerpt="true" />
-        <ul v-if="article.matches.length > 0" class="article-matches mb-2">
-          <li
-            v-for="(match, i) in article.matches"
-            v-bind:key="i"
-            v-html="match.fragment"
-            v-show="match.fragment.trim().length > 0" />
-        </ul>
+        <article-item :item="article" show-meta show-excerpt show-entities show-matches show-link />
         <b-badge
           class="mb-2"
           pill

--- a/src/components/modules/TableOfContents.vue
+++ b/src/components/modules/TableOfContents.vue
@@ -1,103 +1,134 @@
 <template lang="html">
-  <div id="TableOfContents" ref="TableOfContents">
-    <div v-for="page in tableOfContents.pages" class="mb-2 pb-1px page border-bottom">
-      <span class="p-3 d-block text-bold pagenumber">{{$t('page')}} {{page.num}}</span>
-        <b-media
-          :ref="`article-${article.uid}`"
-          class=" article"
-          v-for="article in page.articles"
-          v-bind:class="{active: article.uid === selectedArticleUid}">
-          <a
-            class="p-3 clearfix"
-            href="#"
+  <div class="toc" ref="TableOfContents">
+    <div v-if="flatten">
+      <b-media
+        :ref="`article-${article.uid}`"
+        class="article flatten"
+        v-for="article in articles"
+        v-bind:class="{active: article.uid === selectedArticleUid}"
+        v-on:click.prevent="onClick(article, page)">
+        <article-item :item="article" class="p-3 clearfix"
+          show-excerpt
+          show-link
+          show-entities
+          show-size
+          show-pages
+          show-matches
+          />
+      </b-media>
+    </div>
+    <div v-else>
+      <div v-for="page in tableOfContents.pages" class="mb-2 pb-1px page border-bottom">
+        <span class="p-3 d-block text-bold pagenumber">{{$t('page')}} {{page.num}}</span>
+          <b-media
+            :ref="`article-${article.uid}`"
+            class="article"
+            v-for="article in page.articles"
+            v-bind:class="{active: article.uid === selectedArticleUid}"
             v-on:click.prevent="onClick(article, page)">
-          <div
-            v-if="article.images.length"
-            class="mr-3 images">
-            <b-img
-            fluid-grow
-            class="mb-1 image"
-              v-for="image in article.images"
-              v-bind:src="image.regions[0].iiifFragment" />
-          </div>
-
-          <span class="title"
-            v-if="article.title">
-            <span v-html="article.title" /> &mdash;
-          </span>
-          <span
-            class="excerpt">{{ article.excerpt }}</span>
-          <span class="badge badge-secondary mr-1 pt-1">
-            <span v-if="article.size > 1200" >{{ $t('readingTime', { min: parseInt(article.size / 1200) }) }} / </span>
-            {{ $tc('pp', article.nbPages, { pages: article.pages.map(d => d.num).join(',') }) }}
-          </span>
-
-          <span v-if="article.type !== 'ar'" class="badge badge-secondary mr-1 pt-1">
-            {{ article.type.toUpperCase() }}
-          </span>
-          <!-- {{ article.isCC }} -->
-          <div v-if="article.locations.length" class="article-locations">
-            <span
-              v-for="location in article.locations"
-              v-bind:key="location.uid">
-              {{location.name}}
-              <item-selector :uid="location.uid" :item="location" type="location"/>,
-            </span>
-
-          </div>
-
-          <div v-if="article.persons.length" class="article-persons">
-            <span
-              v-for="person in article.persons"
-              v-bind:key="person.uid">
-              {{person.name}}
-              <item-selector :uid="person.uid" :item="person" type="person"/>,
-            </span>
-          </div>
-          <div class="collapased">
-
-            <div v-if="article.collections && article.collections.length > 0" class="article-collections mb-2">
-              <b-badge
-                v-for="(collection, i) in article.collections"
-                v-bind:key="`${article.article_uid}_col${i}`"
-                variant="info"
-                class="mt-1 mr-1">
-                  {{ collection.name }}
-              </b-badge>
+            <article-item :item="article" class="p-3 clearfix"
+              show-excerpt
+              show-link
+              show-entities
+              show-size
+              show-pages
+              />
+            <!--
+            <a
+              class="p-3 clearfix"
+              href="#"
+              v-on:click.prevent="onClick(article, page)">
+            <div
+              v-if="article.images.length"
+              class="mr-3 images">
+              <b-img
+              fluid-grow
+              class="mb-1 image"
+                v-for="image in article.images"
+                v-bind:src="image.regions[0].iiifFragment" />
             </div>
 
-            <collection-add-to
-            class="mt-2"
-              v-bind:item="article"
-              v-bind:text="$t('add_to_collection')" />
+            <span class="title"
+              v-if="article.title">
+              <span v-html="article.title" /> &mdash;
+            </span>
+            <span
+              class="excerpt">{{ article.excerpt }}</span>
+            <span class="badge badge-secondary mr-1 pt-1">
+              <span v-if="article.size > 1200" >{{ $t('readingTime', { min: parseInt(article.size / 1200) }) }} / </span>
+              {{ $tc('pp', article.nbPages, { pages: article.pages.map(d => d.num).join(',') }) }}
+            </span>
 
-            <ul v-if="article.matches.length > 0" class="article-matches mb-1">
-              <li
-                v-for="(match, i) in article.matches"
-                v-bind:key="i"
-                v-html="match.fragment"
-                v-show="match.fragment.trim().length > 0" />
-            </ul>
+            <span v-if="article.type !== 'ar'" class="badge badge-secondary mr-1 pt-1">
+              {{ article.type.toUpperCase() }}
+            </span>
+            {{ article.isCC }}
+            <div v-if="article.locations.length" class="article-locations">
+              <span
+                v-for="location in article.locations"
+                v-bind:key="location.uid">
+                {{location.name}}
+                <item-selector :uid="location.uid" :item="location" type="location"/>,
+              </span>
 
-            <!-- <ul v-if="article.topics.length > 0" class="article-topics mb-1">
-              <li
-                v-for="topic in article.topics"
-                v-bind:key="topic.topicUid">
-                {{topic.topicUid}} ({{topic.relevance}})
-              </li>
-            </ul> -->
+            </div>
+
+            <div v-if="article.persons.length" class="article-persons">
+              <span
+                v-for="person in article.persons"
+                v-bind:key="person.uid">
+                {{person.name}}
+                <item-selector :uid="person.uid" :item="person" type="person"/>,
+              </span>
+            </div>
+            <div class="collapased">
+
+              <div v-if="article.collections && article.collections.length > 0" class="article-collections mb-2">
+                <b-badge
+                  v-for="(collection, i) in article.collections"
+                  v-bind:key="`${article.article_uid}_col${i}`"
+                  variant="info"
+                  class="mt-1 mr-1">
+                    {{ collection.name }}
+                </b-badge>
+              </div>
+
+              <collection-add-to
+              class="mt-2"
+                v-bind:item="article"
+                v-bind:text="$t('add_to_collection')" />
+
+              <ul v-if="article.matches.length > 0" class="article-matches mb-1">
+                <li
+                  v-for="(match, i) in article.matches"
+                  v-bind:key="i"
+                  v-html="match.fragment"
+                  v-show="match.fragment.trim().length > 0" />
+              </ul> -->
+
+              <!-- <ul v-if="article.topics.length > 0" class="article-topics mb-1">
+                <li
+                  v-for="topic in article.topics"
+                  v-bind:key="topic.topicUid">
+                  {{topic.topicUid}} ({{topic.relevance}})
+                </li>
+              </ul> -->
 
 
+<!--
+            </div>
 
-          </div>
-
-          </a>
-        </b-media>
+            </a> -->
+          </b-media>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
+
+import ArticleItem from './lists/ArticleItem';
 import CollectionAddTo from './CollectionAddTo';
 import ItemSelector from './ItemSelector';
 
@@ -106,6 +137,12 @@ export default {
     selectedArticleUid: '',
   }),
   props: {
+    articles: {
+      type: Array,
+    },
+    flatten: {
+      type: Boolean,
+    },
     tableOfContents: {
       type: Object,
       required: true,
@@ -127,6 +164,7 @@ export default {
   components: {
     CollectionAddTo,
     ItemSelector,
+    ArticleItem,
   },
   methods: {
     orderedTopics(topics) {
@@ -206,10 +244,25 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style lang="scss">
 @import "impresso-theme/src/scss/variables.sass";
+.toc{
+  .article{
+    h2 {
+      font-size: inherit;
+    }
+    &.active {
+      background: white;
+      box-shadow: inset 6px 0px #56CCF2, inset 0px 1px 0px #343a4063;
+    }
+    &.active {
+      background: white;
+      box-shadow: inset 6px 0px gold, inset 0px 1px 0px #343a4063;
+    }
+  }
+}
 
-#TableOfContents{
+.oTableOfContents{
   .page{
     font-size: smaller;
 
@@ -217,9 +270,10 @@ export default {
       &.active{
         // border-bottom: 1px solid #343a40 !important;
         background: white;
+        box-shadow: inset 6px 0px #56CCF2, inset 0px 1px 0px #343a4063;
+
         a{
           // box-shadow: inset 1px 0px #343a40, 0px -1px #343a40, inset -1px 0px #343a40;
-          box-shadow: inset 6px 0px #56CCF2, inset 0px 1px 0px #343a4063;
           background: white; // #f8f9fa;
           .collapased {
             height: auto;
@@ -263,7 +317,6 @@ export default {
   "en": {
     "page": "Page",
     "no_title": "No title",
-    "readingTime": "{min} min read",
     "add_to_collection": "Add to Collection ..."
   },
   "nl": {

--- a/src/components/modules/lists/ArticleItem.vue
+++ b/src/components/modules/lists/ArticleItem.vue
@@ -4,7 +4,10 @@
       <router-link v-if="showLink" :to="{ name: 'article', params: routerLinkParams }" v-html="item.title"></router-link>
       <span v-else v-html="item.title"></span>
     </h2>
-    <div v-else>untitled.</div>
+    <div v-else>
+      <router-link v-if="showLink" :to="{ name: 'article', params: routerLinkParams }" v-html="$t('untitled')"></router-link>
+      <span v-else>{{ $t('untitled') }}</span>
+    </div>
     <div v-if="showMeta" class="article-meta">
       <router-link :to="{ name: 'newspaper', params: { newspaper_uid: item.newspaper.uid }}">
         <strong>{{ item.newspaper.name}}</strong>

--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -1,5 +1,6 @@
 export default {
   en: {
+    untitled: '...',
     language: 'Language',
     languages: {
       de: 'German',
@@ -72,6 +73,8 @@ export default {
       },
     },
     pp: 'no pages | p.{pages} | pp.{pages} ({n} pages)',
+    readingTime: '{min} min read',
+    reducedReadingTime: 'quick reading',
   },
   nl: {
     language: 'Taal',

--- a/src/store/Articles.js
+++ b/src/store/Articles.js
@@ -7,13 +7,7 @@ export default {
   namespaced: true,
   actions: {
     LOAD_ARTICLE(context, uid) {
-      return new Promise((resolve, reject) => {
-        articles.get(uid).then((result) => {
-          resolve(new Article(result));
-        }).catch((err) => {
-          reject(err);
-        });
-      });
+      return articles.get(uid).then(d => new Article(d));
     },
   },
 };

--- a/src/store/Search.js
+++ b/src/store/Search.js
@@ -308,11 +308,29 @@ export default {
         });
       });
     },
-    SEARCH({ state, dispatch, commit, getters }) {
+    GET_SEARCH_RESULTS({ state }, { groupBy, orderBy, page, limit, filters = [] } = {}) {
+      const query = {
+        filters,
+        group_by: groupBy || state.groupBy,
+        page: page || state.paginationCurrentPage,
+        limit: limit || state.paginationPerPage,
+        order_by: orderBy || state.orderBy,
+      };
+      return services.search.find({
+        query,
+      }).then((res) => {
+        if (query.groupBy === 'articles') {
+          res.data = res.data.map(result => new Article(result));
+        }
+        return res;
+      });
+    },
+    SEARCH({ state, dispatch, commit, getters }, { filters = [] } = {}) {
       commit('UPDATE_IS_LOADING', true);
       const facets = ['year', 'language', 'newspaper', 'type', 'country', 'topic'];
       const query = {
-        filters: getters.getSearch.getFilters(),
+        // concat temporary filters, if any
+        filters: getters.getSearch.getFilters().concat(filters),
         facets,
         group_by: state.groupBy,
         page: state.paginationCurrentPage,


### PR DESCRIPTION
This patch fixes #159 and puts ArticleItem component a bit everywhere. Vue boolean properties handle the display of article properties:  comopnent construction is a bit verbose, but overall code is now cleaner. The ArticleItem component is now used in the table of contents, in the search page's search results and in the main article viewer (as heading)

```
<article-item :item="article" show-entities show-excerpt show-meta show-topics/>
```