### PR TITLE
PROPOSAL: Global Event Bus

### DIFF
--- a/src/EventBus.js
+++ b/src/EventBus.js
@@ -1,0 +1,5 @@
+import Vue from 'vue';
+
+const EventBus = new Vue();
+
+export default EventBus;

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import VueI18n from 'vue-i18n';
 import Helpers from '@/plugins/Helpers';
 import ImpressoLayout from '@/plugins/Layout';
 import TawkTo from '@/plugins/TawkTo';
+import EventBus from '@/plugins/EventBus';
 
 import * as services from '@/services';
 
@@ -24,6 +25,7 @@ Vue.use(BootstrapVue);
 Vue.use(VueI18n);
 // custom created plugins
 Vue.use(Helpers);
+Vue.use(EventBus);
 Vue.use(ImpressoLayout);
 Vue.use(TawkTo, { siteId: process.env.TAWK_TO_SITE_ID });
 

--- a/src/plugins/EventBus.js
+++ b/src/plugins/EventBus.js
@@ -1,0 +1,49 @@
+// Global Eventbus
+
+/*
+// Usage outside Vue
+import EventBus from '@/EventBus';
+
+EventBus.$emit('testOutside', {
+  msg: 'test from outside vue',
+});
+
+EventBus.$on('testOutside', (data) => {
+  console.log(data.msg); // test from outside vue
+});
+
+EventBus.$on('testInside', (data) => {
+  console.log(data.msg); // test from inside vue
+});
+
+*/
+
+/*
+// Usage inside Vue component
+...
+methods: {
+  myMethods() {
+    this.$eventBus.$emit('testInside', {
+      msg: 'test from inside vue',
+    });
+  },
+  mounted() {
+    this.$eventBus.$on('testOutside', (data) => {
+      console.log(data.msg); // test from outside vue
+    });
+
+    this.$eventBus.$on('testInside', (data) => {
+      console.log(data.msg); // test from inside vue
+    });
+  },
+},
+...
+*/
+
+import EventBus from '../EventBus';
+
+export default {
+  install(Vue) {
+    Vue.prototype.$eventBus = EventBus;
+  },
+};


### PR DESCRIPTION
Proposal for a global Event Bus. With the Event Bus, we can send ($emit) and catch ($on) messages from inside ánd outside of the Vue instance object.

Documentation in src/plugins/EventBus.js:
```
/*
// Usage outside Vue
import EventBus from '@/EventBus';

EventBus.$emit('testOutside', {
  msg: 'test from outside vue',
});

EventBus.$on('testOutside', (data) => {
  console.log(data.msg); // test from outside vue
});

EventBus.$on('testInside', (data) => {
  console.log(data.msg); // test from inside vue
});

*/

/*
// Usage inside Vue component
...
methods: {
  myMethods() {
    this.$eventBus.$emit('testInside', {
      msg: 'test from inside vue',
    });
  },
  mounted() {
    this.$eventBus.$on('testOutside', (data) => {
      console.log(data.msg); // test from outside vue
    });

    this.$eventBus.$on('testInside', (data) => {
      console.log(data.msg); // test from inside vue
    });
  },
},
...
*/
```