### PR TITLE
Fix UX: store last notification date not to bother user with jobs lists

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -37,7 +37,7 @@
         <b-navbar-nav>
           <b-nav-item-dropdown right no-caret
             v-if="user"
-            ref="ddownJobs" class="p-2">
+            ref="ddownJobs" class="p-2" v-on:hidden="updateLastNotificationDate">
               <template slot="button-content">
                 <div class="dripicons-cloud-download position-relative" style="top:0.25em" />
                 <transition name="bounce">
@@ -206,6 +206,9 @@ export default {
     },
   },
   methods: {
+    updateLastNotificationDate() {
+      this.$store.dispatch('settings/UPDATE_LAST_NOTIFICATION_DATE');
+    },
     openExplorer() {
       this.$store.dispatch('explorer/SHOW', {});
     },
@@ -226,10 +229,16 @@ export default {
     },
   },
   watch: {
-    runningJobs: {
-      handler(val) {
-        if (val.length > 0 && this.$refs.ddownJobs) {
-          this.$refs.ddownJobs.show();
+    jobs: {
+      handler(jobs) {
+        if (jobs.length && this.$refs.ddownJobs) {
+          const lastModifiedDate = new Date(jobs.map(d => d.lastModifiedDate).sort().pop());
+          if (this.$store.getters['settings/lastNotificationDate'] - lastModifiedDate < 0) {
+            console.info('Stored settings.lastNotificationDate is behind a job lastModifiedDate, show job dropdown.');
+            this.$refs.ddownJobs.show();
+          } else {
+            console.info('Stored settings.lastNotificationDate is synced with job lastModifiedDate, nothing to show.');
+          }
         }
       },
     },

--- a/src/main.js
+++ b/src/main.js
@@ -63,3 +63,5 @@ services.app.reAuthenticate().catch((err) => {
     },
   });
 });
+
+console.info('Last notification date', store.state.settings.lastNotificationDate);

--- a/src/store/Settings.js
+++ b/src/store/Settings.js
@@ -3,6 +3,7 @@ export default {
   state: {
     language_code: 'en',
     termsAgreed: false,
+    lastNotificationDate: (new Date(0)).toISOString(),
   },
   getters: {
   },
@@ -13,11 +14,18 @@ export default {
     SET_TERMS_AGREED(state, value) {
       state.termsAgreed = Boolean(value);
     },
+    SET_LAST_NOTIFICATION_DATE(state) {
+      state.lastNotificationDate = (new Date()).toISOString();
+    },
   },
   actions: {
     ACCEPT_TERMS_OF_USE({ commit }) {
       console.info('settings/ACCEPT_TERMS_OF_USE');
       commit('SET_TERMS_AGREED', true);
+    },
+    HIDE_JOBS_NOTIFICATION({ commit }) {
+      console.info('settings/HIDE_JOBS_NOTIFICATION');
+      commit('SET_LAST_NOTIFICATION_DATE');
     },
   },
 };

--- a/src/store/Settings.js
+++ b/src/store/Settings.js
@@ -6,6 +6,9 @@ export default {
     lastNotificationDate: (new Date(0)).toISOString(),
   },
   getters: {
+    lastNotificationDate(state) {
+      return new Date(state.lastNotificationDate);
+    },
   },
   mutations: {
     SET_LANGUAGE(state, payload) {
@@ -23,8 +26,8 @@ export default {
       console.info('settings/ACCEPT_TERMS_OF_USE');
       commit('SET_TERMS_AGREED', true);
     },
-    HIDE_JOBS_NOTIFICATION({ commit }) {
-      console.info('settings/HIDE_JOBS_NOTIFICATION');
+    UPDATE_LAST_NOTIFICATION_DATE({ commit }) {
+      console.info('@settings/UPDATE_LAST_NOTIFICATION_DATE');
       commit('SET_LAST_NOTIFICATION_DATE');
     },
   },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -106,6 +106,7 @@ export default new Vuex.Store({
     key: 'impresso',
     paths: [
       'settings.termsAgreed',
+      'settings.lastNotificationDate',
       'settings.language_code',
       'search.searches',
       'search.displaySortBy',


### PR DESCRIPTION
Update last notification date only when an user closes the dropdown