### PR TITLE
Add filtered labels in QueryComparison store

### DIFF
--- a/src/components/SearchQueriesComparisonPage.vue
+++ b/src/components/SearchQueriesComparisonPage.vue
@@ -284,6 +284,11 @@ export default {
           facets: prepareFacets(result.info.facets),
           total: result.total,
         };
+        // update searchQuery
+        await this.$store.dispatch('queryComparison/UPDATE_QUERY_COMPONENTS', {
+          searchQueryId: `p-${resultIndex}`,
+          queryComponents: result.info.queryComponents,
+        });
         // https://vuejs.org/v2/guide/list.html#Caveats
         this.$set(this.queriesResults, resultIndex, resultValue);
       } finally {

--- a/src/store/QueryComparison.js
+++ b/src/store/QueryComparison.js
@@ -36,6 +36,10 @@ export default {
       getQueryById(state, searchQueryId)
         .updateFilterItem({ filter, item, uid });
     },
+    UPDATE_QUERY_COMPONENTS(state, { searchQueryId, queryComponents }) {
+      getQueryById(state, searchQueryId)
+        .enrichFilters(queryComponents);
+    },
     CLEAR(state) {
       state.searchQueries = {};
     },
@@ -55,6 +59,9 @@ export default {
     },
     UPDATE_FILTER_ITEM({ commit }, message) {
       commit('UPDATE_FILTER_ITEM', message);
+    },
+    UPDATE_QUERY_COMPONENTS({ commit }, { searchQueryId, queryComponents }) {
+      commit('UPDATE_QUERY_COMPONENTS', { searchQueryId, queryComponents });
     },
     SET_SEARCH_QUERY_FILTERS({ commit }, { searchQueryId, filters }) {
       commit('SET_SEARCH_QUERY_FILTERS', { searchQueryId, filters });


### PR DESCRIPTION
In search.find response, the `info.queryComponents` property contains the filters enriched by resolved items (newspapers or topic instances)