### PR TITLE
scale images to 50% of native size

### DIFF
--- a/src/components/FaqPage.vue
+++ b/src/components/FaqPage.vue
@@ -54,6 +54,7 @@ export default {
 <style lang="scss">
   img {
     max-width: 100%;
+    zoom: 50%;
   }
   .accordion-toggle {
     cursor: n-resize;


### PR DESCRIPTION
this solution works on webkit browsers and IE
not working on FF right now -- that would require JS on each image ... or uploading non-retina images