### PR TITLE
Search Text Reuse clusters by cluster Id

### DIFF
--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -109,10 +109,10 @@ export default {
     };
   },
   updated() {
-    const { height } = document.querySelector('#TheHeader').getBoundingClientRect();
-    this.viewerTopOffset = height;
+    const { height } = document.querySelector('#TheHeader').getBoundingClientRect()
+    this.viewerTopOffset = height
 
-    [...document.querySelectorAll('.tr-passage')].map(element => {
+    document.querySelectorAll('.tr-passage').forEach(element => {
       element.removeEventListener('mouseenter', this.mouseenterPassageHandler)
       element.addEventListener('mouseenter', this.mouseenterPassageHandler)
       element.removeEventListener('mouseleave', this.mouseleavePassageHandler)
@@ -223,7 +223,7 @@ export default {
     },
     passageClickHandler() {
       this.$router.push({
-        name: 'text-reuse-clusters-passages',
+        name: 'text-reuse-clusters',
         query: {
           clusterId: this.selectedClusterId
         }

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -46,6 +46,8 @@ const needsLockScreen = p => [
   'ngram-trends.create',
 ].includes(p);
 
+const silentErrorCodes = [404]
+
 app.hooks({
   before: {
     all: [
@@ -83,7 +85,7 @@ app.hooks({
             console.warn('app.hooks.error.all:ignoreErrors',  context.error);
           } else if (route === 'authentication.remove' && context.error.name === 'NotAuthenticated') {
             console.info('Ingore NotAuthenticated error on "authentication.remove" route.');
-          } else {
+          } else if (!silentErrorCodes.includes(context.error.code)) {
             window.app.$store.dispatch('DISPLAY_ERROR', {
               error: context.error,
               origin: 'app.hooks.error.all',


### PR DESCRIPTION
When `search text` in clusters search is a specially formatted cluster Id (e.g. `#12345`), search for this cluster only ignoring all the filters. This is primarily needed when navigating from article page and passing over cluster Id. With this change the cluster search page will load the cluster into the sidebar and select it instead of displaying the first page of all clusters.