### PR TITLE
Do not search collections in autocomplete when the user is not logged in

### DIFF
--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -127,6 +127,9 @@ export default {
     },
   },
   computed: {
+    user() {
+      return this.$store.getters['user/user'];
+    },
     staticSuggestions() {
       return this.initialSuggestions.concat(this.recentSuggestions).map((d, idx) => ({
         ...d,
@@ -234,12 +237,14 @@ export default {
         }).then((res) => {
           this.suggestions = [...res, ...this.collectionSuggestions];
         })
-        this.$store.dispatch('autocomplete/SUGGEST_COLLECTIONS', {
-          q: this.q.trim(),
-        }).then((res) => {
-          this.collectionSuggestions = res;
-          this.suggestions = [...res, ...this.suggestions];
-        })
+        if (this.user) {
+          this.$store.dispatch('autocomplete/SUGGEST_COLLECTIONS', {
+            q: this.q.trim(),
+          }).then((res) => {
+            this.collectionSuggestions = res;
+            this.suggestions = [...res, ...this.suggestions];
+          })
+        }
       } else {
         // if length of the query is 0 then we clear the suggestions
         this.suggestions = [];

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -52,7 +52,10 @@ export default class Entity {
   }
 
   static getTypeFromUid(uid) {
-    const t = String(uid.match(/^aida-\d+-(\d+)/)[1]);
+    if (uid == null) return;
+    const match = uid.match(/^aida-\d+-(\d+)/)
+    if (match == null) return;
+    const t = String(match[1]);
     return TYPES[t] || t;
   }
 }


### PR DESCRIPTION
* Do not search collections in autocomplete when the user is not logged in. This produces a "Not Authenticated" error.