### PR TITLE
Hotfix load timeline domain (years) from API & stacked-bars-facets UI

### DIFF
--- a/src/components/CollectionDetailPage.vue
+++ b/src/components/CollectionDetailPage.vue
@@ -187,7 +187,7 @@
         </div>
       </timeline>
 
-      <b-container>
+      <b-container fluid class="my-3">
         <b-row>
           <b-col sm="12" md="12" lg="6" xl="4" v-for="(facet, idx) in facets" v-bind:key="idx">
             <stacked-bars-panel
@@ -271,16 +271,6 @@ const TAB_OVERVIEW = 'overview';
 const TAB_RECOMMENDATIONS = 'recommendations';
 
 export default {
-  props: {
-    startYear: {
-      type: Number,
-      default: 1740,
-    },
-    endYear: {
-      type: Number,
-      default: 2020,
-    },
-  },
   data: () => ({
     tab: {},
     collection: new Collection(),
@@ -302,6 +292,12 @@ export default {
     CollectionRecommendationsPanel,
   },
   computed: {
+    startYear() {
+      return window.impressoDocumentsYearSpan.firstYear;
+    },
+    endYear() {
+      return window.impressoDocumentsYearSpan.lastYear;
+    },
     filters: mapFilters(),
     searchPageLink() {
       if (!this.collection) {

--- a/src/components/EntitiesDetailPage.vue
+++ b/src/components/EntitiesDetailPage.vue
@@ -114,6 +114,7 @@
           </section>
         </b-navbar>
         <timeline
+              :domain="[startYear, endYear]"
               :contrast="false"
               :values="timevalues">
           <div slot-scope="tooltipScope">
@@ -181,6 +182,12 @@ export default {
     MentionItem,
   },
   computed: {
+    startYear() {
+      return window.impressoDocumentsYearSpan.firstYear;
+    },
+    endYear() {
+      return window.impressoDocumentsYearSpan.lastYear;
+    },
     searchPageLink() {
       if (!this.entity) {
         return { name: 'search' };

--- a/src/components/NewspapersDetailPage.vue
+++ b/src/components/NewspapersDetailPage.vue
@@ -61,6 +61,7 @@
           <p class="mx-2 description small">number of articles extracted which are available in impresso</p>
         </div>
         <timeline
+              :domain="[startYear, endYear]"
               :contrast="false"
               :values="timevalues">
           <div slot-scope="tooltipScope">
@@ -72,7 +73,7 @@
         </timeline>
 
         <b-container class="my-3">
-          <h2>Facets – top ten buckets</h2>
+          <!-- <h2>Facets – top ten buckets</h2> -->
           <b-row>
             <b-col sm="12" md="12" lg="6" xl="4" v-for="(facet, idx) in facets" v-bind:key="idx">
               <stacked-bars-panel
@@ -245,6 +246,12 @@ export default {
         return false;
       },
     },
+    startYear() {
+      return window.impressoDocumentsYearSpan.firstYear;
+    },
+    endYear() {
+      return window.impressoDocumentsYearSpan.lastYear;
+    }
   },
   methods: {
     applyFilter() {

--- a/src/components/TopicDetailPage.vue
+++ b/src/components/TopicDetailPage.vue
@@ -223,6 +223,7 @@ export default {
       });
     },
     async loadFacets() {
+      this.facets = [];
       const query = {
         filters: [{
           type: 'topic',

--- a/src/components/TopicDetailPage.vue
+++ b/src/components/TopicDetailPage.vue
@@ -90,6 +90,7 @@
         <p class="description small">number of articles where this topic is relevant</p>
       </div>
       <timeline
+            :domain="[startYear, endYear]"
             :contrast="false"
             :values="timevalues">
         <div slot-scope="tooltipScope">
@@ -186,6 +187,18 @@ export default {
         },
       ];
     },
+    impressoCollectionStartDate() {
+      return new Date(window.impressoDocumentsDateSpan.firstDate)
+    },
+    impressoCollectionEndDate() {
+      return new Date(window.impressoDocumentsDateSpan.lastDate)
+    },
+    startYear() {
+      return this.impressoCollectionStartDate.getFullYear();
+    },
+    endYear() {
+      return this.impressoCollectionEndDate.getFullYear();
+    }
   },
   methods: {
     async onInputPagination(page) {

--- a/src/components/modules/SearchSidebar.vue
+++ b/src/components/modules/SearchSidebar.vue
@@ -96,18 +96,12 @@ export default {
     infoButtonName() {
       return `how-${this.contextTag}-work-with-search-filters`
     },
-    impressoCollectionStartDate() {
-      return new Date(window.impressoDocumentsDateSpan.firstDate)
-    },
-    impressoCollectionEndDate() {
-      return new Date(window.impressoDocumentsDateSpan.lastDate)
-    },
     startYear() {
-      return this.impressoCollectionStartDate.getFullYear();
+      return window.impressoDocumentsYearSpan.firstYear;
     },
     endYear() {
-      return this.impressoCollectionEndDate.getFullYear();
-    }
+      return window.impressoDocumentsYearSpan.lastYear;
+    },
   },
   components: {
     SearchPills,

--- a/src/components/modules/SearchSidebar.vue
+++ b/src/components/modules/SearchSidebar.vue
@@ -35,6 +35,8 @@
       <search-facets
         :facets="facets"
         :filters="filters"
+        :start-year="startYear"
+        :end-year="endYear"
         @changed="handleFiltersChanged"/>
     </div>
   </i-layout-section>
@@ -94,6 +96,18 @@ export default {
     infoButtonName() {
       return `how-${this.contextTag}-work-with-search-filters`
     },
+    impressoCollectionStartDate() {
+      return new Date(window.impressoDocumentsDateSpan.firstDate)
+    },
+    impressoCollectionEndDate() {
+      return new Date(window.impressoDocumentsDateSpan.lastDate)
+    },
+    startYear() {
+      return this.impressoCollectionStartDate.getFullYear();
+    },
+    endYear() {
+      return this.impressoCollectionEndDate.getFullYear();
+    }
   },
   components: {
     SearchPills,

--- a/src/main.js
+++ b/src/main.js
@@ -124,6 +124,10 @@ Promise.race([
   window.impressoDocumentsDateSpan = documentsDateSpan
   window.impressoNewspapers = newspapers
   window.impressoFeatures = features
+  window.impressoDocumentsYearSpan = {
+    firstYear: (new Date(documentsDateSpan.firstDate)).getFullYear(),
+    lastYear: (new Date(documentsDateSpan.lastDate)).getFullYear()
+  }
 
   window.app = new Vue({
     el: '#app',


### PR DESCRIPTION
- Store startYear and endYear in window
- added startYear and endYear as computed properties
- fix display of stacked-bars-chart in NewspaperDetailPage
- add stacked-bars-chart facets in TopicDetailPage