### PR TITLE
created mixins for range sliders, added classes for vue-range-slider

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -258,8 +258,8 @@ $clr-grey-900: #ddd;
 @mixin slider-dot {
   border-radius: 50%;
   background-color: $clr-bg-primary ;
-  border: 0.1rem solid $clr-secondary ;
-  box-shadow: 0 0 0 0.1rem $clr-bg-primary;
+  border: 0.1rem solid black ;
+  box-shadow: none;
 }
 @mixin slider-dot-focus {
   border-color: $clr-accent-secondary;
@@ -326,15 +326,18 @@ input[type="range"]:active::-ms-thumb {
 }
 
 .vue-slider .vue-slider-process {
-  background-color: $clr-accent-secondary;
+  background-color: black;
   height: 14px !important;
   margin-top: -7px;
 }
+
 .vue-slider .vue-slider-dot-tooltip-inner {
   border-color: $clr-primary;
   background-color: $clr-primary;
-  border-radius: 0;
+  padding: 0px 5px 2px 5px;
+  border-radius: 1px;
 }
+
 .vue-slider .vue-slider-mark-step {
     width: 1px;
     height: 5px;

--- a/src/App.vue
+++ b/src/App.vue
@@ -244,61 +244,97 @@ $clr-grey-900: #ddd;
   border-color: $clr-tertiary;
 }
 
-input[type="range"]::-webkit-slider-runnable-track {
-  height: 0.1rem;
-  background-color: $clr-secondary;
-  border-radius: 2px;
-}
-input[type="range"]::-moz-range-track {
-  height: 0.1rem;
-  background-color: $clr-secondary;
-  border-radius: 2px;
-}
-input[type="range"]::-ms-track {
-  height: 0.1rem;
-  background-color: $clr-secondary;
-  border-radius: 2px;
-}
+// --- input range sliders ---
+// using classes that are browser specific,
+// stacking them together would invalidate the whole class
+// for other browsers
+// Using mixins to avoid duplicate declarations
 
-input[type="range"]::-webkit-slider-thumb {
-  margin-top: -0.45rem;
-  border-radius: 50%;
-  background-color: $clr-bg-primary;
-  border: 0.1rem solid $clr-secondary;
-  box-shadow: 0 0 0 0.1rem $clr-bg-primary;;
+@mixin slider-rail {
+  height: 0.1rem;
+  background-color: $clr-secondary;
+  border-radius: 2px;
 }
-input[type="range"]:focus::-webkit-slider-thumb {
+@mixin slider-dot {
+  border-radius: 50%;
+  background-color: $clr-bg-primary ;
+  border: 0.1rem solid $clr-secondary ;
+  box-shadow: 0 0 0 0.1rem $clr-bg-primary;
+}
+@mixin slider-dot-focus {
   border-color: $clr-accent-secondary;
 }
-input[type="range"]:active::-webkit-slider-thumb {
+@mixin slider-dot-active {
   background-color: $clr-accent-secondary;
+}
+
+.vue-slider .vue-slider-rail {
+  @include slider-rail;
+}
+input[type="range"]::-webkit-slider-runnable-track {
+  @include slider-rail;
+}
+input[type="range"]::-moz-range-track {
+  @include slider-rail;
+}
+input[type="range"]::-ms-track {
+  @include slider-rail;
+}
+
+.vue-slider .vue-slider-dot-handle {
+  @include slider-dot;
+  transition: all 0.1s;
+}
+input[type="range"]::-webkit-slider-thumb {
+  margin-top: -0.45rem;
+  @include slider-dot;
 }
 input[type="range"]::-moz-range-thumb {
   margin-top: -0.45rem;
-  border-radius: 50%;
-  background-color: $clr-bg-primary;
-  border: 0.1rem solid $clr-secondary;
-  box-shadow: 0 0 0 0.1rem $clr-bg-primary;;
-}
-input[type="range"]:focus::-moz-range-thumb {
-  border-color: $clr-accent-secondary;
-}
-input[type="range"]:active::-moz-range-thumb {
-  background-color: $clr-accent-secondary;
+  @include slider-dot;
 }
 input[type="range"]::-ms-thumb {
   margin-top: -0.45rem;
-  border-radius: 50%;
-  background-color: $clr-bg-primary;
-  border: 0.1rem solid $clr-secondary;
-  box-shadow: 0 0 0 0.1rem $clr-bg-primary;;
+  @include slider-dot;
+}
+
+.vue-slider:focus .vue-slider-dot-handle {
+  @include slider-dot-focus;
+}
+input[type="range"]:focus::-webkit-slider-thumb {
+  @include slider-dot-focus;
+}
+input[type="range"]:focus::-moz-range-thumb {
+  @include slider-dot-focus;
 }
 input[type="range"]:focus::-ms-thumb {
-  border-color: $clr-accent-secondary;
+  @include slider-dot-focus;
+}
+
+.vue-slider-dot-focus .vue-slider-dot-handle-focus {
+  @include slider-dot-focus;
+  @include slider-dot-active;
+}
+input[type="range"]:active::-webkit-slider-thumb {
+  @include slider-dot-active;
+}
+input[type="range"]:active::-moz-range-thumb {
+  @include slider-dot-active;
 }
 input[type="range"]:active::-ms-thumb {
+  @include slider-dot-active;
+}
+
+.vue-slider .vue-slider-process {
   background-color: $clr-accent-secondary;
 }
+.vue-slider .vue-slider-dot-tooltip-inner {
+  border-color: $clr-primary;
+  background-color: $clr-primary;
+  border-radius: 0;
+}
+
+
 
 
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -327,11 +327,20 @@ input[type="range"]:active::-ms-thumb {
 
 .vue-slider .vue-slider-process {
   background-color: $clr-accent-secondary;
+  height: 14px !important;
+  margin-top: -7px;
 }
 .vue-slider .vue-slider-dot-tooltip-inner {
   border-color: $clr-primary;
   background-color: $clr-primary;
   border-radius: 0;
+}
+.vue-slider .vue-slider-mark-step {
+    width: 1px;
+    height: 5px;
+    border-radius: 0;
+    background-color: currentColor;
+    margin-top: -1.5px;
 }
 
 


### PR DESCRIPTION
vue-range-slider is more flexible and much easier to style than the native input range.

however it lacks accessibility features, no `:focus` state, no keyboard navigation.
although this can be added, see https://nightcatsama.github.io/vue-slider-component/#/api/methods?hash=focusindex