### PR TITLE
Fix/issue viewer text

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -457,7 +457,7 @@ input[type="range"]:active::-ms-thumb {
 }
 
 .viz-bar {
-  height: 2px;
+  height: 3px;
 }
 
 .icon-link {

--- a/src/components/IssueViewerBookmarker.vue
+++ b/src/components/IssueViewerBookmarker.vue
@@ -1,14 +1,16 @@
 <template lang="html">
   <div class="issue-viewer-bookmarker" :class="{ active, visible }">
-    <div class="bg-dark p-2 drop-shadow d-flex align-items-center">
+    <div class="bg-dark p-2 drop-shadow d-flex align-items-center" style="background: black !important">
       <div class="mr-2">
         {{$t('label_selected_article') }}
       </div>
       <div class="text-white font-weight-bold mr-2 text-ellipsis">{{ title }}</div>"
-      <b-button class="mx-2" variant="outline-primary"
-        size="sm"
+      <b-button size="sm" class="mx-2 text-white" variant="outline-primary"
         @click="$emit('click-full-text')">
-        {{ $t('label_full_text') }}
+        <div class="d-flex align-items-center">
+          {{ $t('closeReadingView') }}
+          <div class="d-flex dripicons dripicons-align-justify ml-2" />
+        </div>
       </b-button>
       <b-button pill class="dripicons-cross p-0"
         style="width:1.5em; height:1.5em; line-height: 1.75em"

--- a/src/components/IssueViewerTableOfContents.vue
+++ b/src/components/IssueViewerTableOfContents.vue
@@ -14,7 +14,7 @@
             <a class="small-caps" :class="{
               'font-weight-bold': item.uid === selectedArticleId
             }" @click="$emit('click-full-text', item.uid)">
-              {{ $t('label_full_text') }}
+              {{ $t('closeReadingView') }}
             </a>
           </div>
         </template>

--- a/src/components/base/VizBar.vue
+++ b/src/components/base/VizBar.vue
@@ -1,24 +1,21 @@
 <template>
-  <div v-b-tooltip.hover.right :title="toolTitle" class="w-100">
-
-    <div class="clearfix">
-      <div class="float-left w-75">
-        <item-label :item="item" :type="type" />
+  <div>
+    <div class="d-flex">
+      <div class="mr-2 small-caps" v-if="showPercent">{{ toolTitle }}</div>
+      <div class="flex-grow-1">
+        <item-label :item="item" :type="type" class="mr-1"/>
         <item-selector
-          :uid="uid"
-          :item="item"
-          :type="type"
-          :default-click-action-disabled="defaultClickActionDisabled"
-          @click="param => $emit('click', param)"/>
+        :uid="uid"
+        :item="item"
+        :type="type"
+        :default-click-action-disabled="defaultClickActionDisabled"
+        @click="param => $emit('click', param)"/>
       </div>
-      <div v-if="count" class="float-right w-25 text-right">
-        {{$n(count)}}
-      </div>
+      <div v-if="count">{{ $n(count) }}</div>
     </div>
-    <div class="bg-white w-100">
-      <div class="bg-accent-secondary viz-bar" :style="`width:${percent}%;`" />
+    <div class="bg-white w-100" :class="{ 'border-bottom border-dark': showBorder }">
+      <div class="bg-dark viz-bar" :style="`width:${percent}%;`" />
     </div>
-
   </div>
 </template>
 
@@ -28,6 +25,8 @@ import ItemSelector from '../modules/ItemSelector';
 
 export default {
   props: {
+    showBorder: Boolean,
+    showPercent: Boolean,
     percent: { type: Number },
     count: { type: Number },
     uid: { type: String },

--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -2,7 +2,7 @@
   <div id="IssueViewerText" class="px-3 bg-light">
     <i-spinner v-if="!article" class="text-center p-5" />
     <div v-if="article">
-      <article-item :item="article" show-entities show-excerpt show-topics/>
+      <article-item :item="article" show-entities show-topics/>
       <div class="my-2" />
       <collection-add-to :item="article" :text="$t('add_to_collection')" />
       <b-badge

--- a/src/components/modules/IssueViewerText.vue
+++ b/src/components/modules/IssueViewerText.vue
@@ -44,7 +44,7 @@
             class="col"
             :class="{ 'col-sm-7': article.isCC, 'col-sm-12': !article.isCC }">
             <div class='region py-3'>
-              <annotated-text
+              <annotated-text v-if="regionsAnnotationTree[i]"
                 :children="regionsAnnotationTree[i].children"
                 :cluster-colours="clusterColourMap"
                 :selected-cluster-id="selectedClusterId"

--- a/src/components/modules/lists/ArticleItem.vue
+++ b/src/components/modules/lists/ArticleItem.vue
@@ -54,18 +54,20 @@
         </span>
       </div>
     </div>
-    <div v-if="showTopics" class="small article-extras article-topics mt-2">
+    <div v-if="showTopics" class="small article-extras article-topics my-2">
       <b-badge variant="light" class="mr-1 small-caps bg-medium">topics</b-badge>
-      <div v-if="item.topics.length">
-        <div v-for="(rel, idx) in item.topics" v-bind:key="idx" class="mx-1 mb-1">
+      <b-row v-if="item.topics.length">
+        <b-col lg="6" xl="4" class="my-1" v-for="(rel, idx) in item.topics" v-bind:key="idx">
           <viz-bar
+            show-border
+            show-percent
             :percent="rel.relevance * 100"
             :uid="rel.topic.uid"
             :item="rel.topic"
             type="topic"
             />
-        </div>
-      </div>
+        </b-col>
+      </b-row>
     </div>
     <div v-if="showMatches">
       <ul v-if="item.matches.length" class="article-matches mt-1 p-0">

--- a/src/components/modules/vis/StackedBarsPanel.vue
+++ b/src/components/modules/vis/StackedBarsPanel.vue
@@ -13,7 +13,7 @@
           :class="`bar-container row my-1 small ${isHovered(bucket) ? 'hilight' : ''}`"
           @mouseover="onHover(bucket)">
 
-          <viz-bar
+          <viz-bar class="w-100"
             :percent="toScaledValue(bucket.count) * 100"
             :count="bucket.count"
             :uid="bucket.item ? bucket.item.uid : null"

--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -366,6 +366,8 @@ export default {
     currentSearch: 'current search',
     lexicalOverlap: 'lexical overlap',
     notFound: '(this is an empty list)',
+    facsimileView: 'Facsimile',
+    closeReadingView: 'Transcript',
   },
   nl: {
     language: 'Taal',

--- a/src/pages/IssueViewerPage.vue
+++ b/src/pages/IssueViewerPage.vue
@@ -87,19 +87,33 @@
             </b-button>
           </b-navbar-nav>
 
-          <b-button
-            class="ml-2"
-            :variant="outlinesVisible ? 'primary' : 'outline-primary'" size="sm"
-            @click="outlinesVisible = !outlinesVisible">
-            <div class="d-flex flex-row align-items-center">
-              <div class="d-flex dripicons dripicons-preview mr-2" />
-              <div v-if="outlinesVisible">{{$t('toggle_outlines_on')}}</div>
-              <div v-else>{{$t('toggle_outlines_off')}}</div>
-            </div>
-          </b-button>
+          <b-navbar-nav class="p-2" v-if="!isArticleTextDisplayed">
+            <b-button
+              :variant="outlinesVisible ? 'primary' : 'outline-primary'" size="sm"
+              @click="outlinesVisible = !outlinesVisible">
+              <div class="d-flex flex-row align-items-center">
+                <div class="d-flex dripicons dripicons-preview mr-2" />
+                <div v-if="outlinesVisible">{{$t('toggle_outlines_on')}}</div>
+                <div v-else>{{$t('toggle_outlines_off')}}</div>
+              </div>
+            </b-button>
+          </b-navbar-nav>
 
-          <b-navbar-nav class="ml-auto p-2" v-if="selectedArticle && isArticleTextDisplayed">
-            <b-button size="sm" variant="outline-primary" @click="isArticleTextDisplayed = false">{{ $t('facsimileView') }}</b-button>
+          <b-navbar-nav class="ml-auto p-2" v-if="selectedArticle">
+            <b-button-group>
+              <b-button size="sm" :class="{ active: !isArticleTextDisplayed }" variant="outline-primary" @click="isArticleTextDisplayed = false">
+                <div class="d-flex align-items-center">
+                  {{ $t('facsimileView') }}
+                  <div class="d-flex dripicons dripicons-article ml-2" />
+                </div>
+              </b-button>
+              <b-button size="sm" :class="{ active: isArticleTextDisplayed }" variant="outline-primary" @click="isArticleTextDisplayed = true">
+                <div class="d-flex align-items-center">
+                  {{ $t('closeReadingView') }}
+                  <div class="d-flex dripicons dripicons-align-justify ml-2" />
+                </div>
+              </b-button>
+            </b-button-group>
           </b-navbar-nav>
         </b-navbar>
       </div>
@@ -531,8 +545,6 @@ export default {
     "table_of_contents": "table of contents",
     "toggle_outlines_on": "outlines: on",
     "toggle_outlines_off": "Outlines: off",
-    "facsimileView": "Facsimile",
-    "closeReadingView": "Transcript",
     "filter_included_only": "show only matching articles (no results) | show only matching articles (<b>1</b> result) | show only matching articles (<b>{n}</b> results)"
   }
 }

--- a/src/pages/IssueViewerPage.vue
+++ b/src/pages/IssueViewerPage.vue
@@ -133,7 +133,7 @@
           :article="selectedArticle"
           :visible="!isArticleTextDisplayed"/>
 
-        <div class="position-absolute d-flex drop-shadow bg-dark border-radius" style="bottom: 1rem">
+        <div class="position-absolute d-flex drop-shadow bg-dark border-radius" style="bottom: 1rem" v-if="!isArticleTextDisplayed">
           <div v-for="(item, i) in issue.pages" :key="i" @click="changeCurrentPageIndex(i)">
             <page-item class="bg-dark p-2"
             :active="pageId === item.uid"


### PR DESCRIPTION
- viz-bar component, show percent in article view and omit it in I&C
- use same label "transcript" and bring back the facsimile/transcript buttons only when needed
- fix annotation in article-view

e.g test
http://localhost:8080/issue/DTT-1955-04-20-a/view?p=9&asq=true&sq=ChAQAhgHIAEqCGVpbnN0ZWluCjIQAhgKKiwxOTA4LTA1LTI0VDAwOjAwOjAwWiBUTyAxOTYzLTA2LTI3VDIzOjU5OjU5WgoCGAIKEBgaKgUyMzIyOCoFNDU5MjU%3D&articleId=i0002&text=1
