### PR TITLE
pass filters as payload to services.search.create

### DIFF
--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -484,7 +484,12 @@ export default {
           name: this.inputName,
           description: this.inputDescription,
         }).then((collection) => {
-          this.$store.dispatch('search/CREATE_COLLECTION_FROM_QUERY', collection.uid);
+          console.log(collection);
+          const payload = {
+            filters: this.filters.map(getFilterQuery),
+            collectionUid: collection.uid
+          };
+          this.$store.dispatch('search/CREATE_COLLECTION_FROM_QUERY', payload);
         });
       }
     },

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -484,7 +484,6 @@ export default {
           name: this.inputName,
           description: this.inputDescription,
         }).then((collection) => {
-          console.log(collection);
           const payload = {
             filters: this.filters.map(getFilterQuery),
             collectionUid: collection.uid

--- a/src/store/Search.js
+++ b/src/store/Search.js
@@ -297,12 +297,13 @@ export default {
       //   context.commit('ADD_FILTER', filter);
       // }
     },
-    CREATE_COLLECTION_FROM_QUERY(context, collectionUid) {
+    CREATE_COLLECTION_FROM_QUERY(context, payload) {
+      console.log(payload, services.search.methods.create);
       return new Promise((resolve) => {
         services.search.create({
           group_by: 'articles',
-          filters: context.getters.getSearch.getFilters(),
-          collection_uid: collectionUid,
+          filters: payload.filters,
+          collection_uid: payload.collectionUid,
         }).then(res => resolve(res));
       });
     },

--- a/src/store/Search.js
+++ b/src/store/Search.js
@@ -297,13 +297,12 @@ export default {
       //   context.commit('ADD_FILTER', filter);
       // }
     },
-    CREATE_COLLECTION_FROM_QUERY(context, payload) {
-      console.log(payload, services.search.methods.create);
+    CREATE_COLLECTION_FROM_QUERY(context, { filters, collectionUid }) {
       return new Promise((resolve) => {
         services.search.create({
           group_by: 'articles',
-          filters: payload.filters,
-          collection_uid: payload.collectionUid,
+          filters: filters,
+          collection_uid: collectionUid,
         }).then(res => resolve(res));
       });
     },


### PR DESCRIPTION
collection.uid and filters array get passed correctly, however I receive error 
**Timeout: Timeout of 130000ms exceeded calling create on search paths.search.create**

Also still see this (probably unrelated) error on search page: "TypeError: Cannot read property 'c' of null"

More detailled error message :
```
Timeout {type: "FeathersError", name: "Timeout", message: "Timeout of 130000ms exceeded calling create on search", code: 408, className: "timeout", …}
className: "timeout"
code: 408
data: {timeout: 130000, method: "create", path: "search"}
errors: {}
hook:
app: {init: ƒ, get: ƒ, set: ƒ, disable: ƒ, disabled: ƒ, …}
arguments: [{…}]
data:
collection_uid: "local-ps-yj_w-3jJ"
filters: Array(4)
0: {type: "hasTextContents"}
1: {type: "string", op: "OR", q: Array(1), precision: "exact"}
2: {type: "string", op: "OR", q: Array(1), precision: "exact"}
3: {type: "hasTextContents"}
length: 4
__proto__: Array(0)
group_by: "articles"
__proto__: Object
method: "create"
params:
accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6ImFjY2VzcyJ9.eyJ1c2VySWQiOiJsb2NhbC1wcyIsImlhdCI6MTU5ODk3NjQ3OSwiZXhwIjoxNTk5NTgxMjc5LCJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjMwMzAiLCJpc3MiOiJpbXByZXNzby12MSIsInN1YiI6IjMiLCJqdGkiOiI4ZjRiYzE2MC1iZWYwLTQxOWMtOGFlMC05Y2ZhNGRjZWM2ODIifQ.uMKgdhZpY70QSZBzDoJVYs20qyoZ5kQKlOdVKAfb0H0"
authentication: {strategy: "jwt", accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6ImFjY2VzcyJ9.eyJ1c2VyS…DIifQ.uMKgdhZpY70QSZBzDoJVYs20qyoZ5kQKlOdVKAfb0H0", payload: {…}}
user: {id: 3, username: "paul.schroeder@uni.lu", firstname: "Paul", lastname: "Schroeder", isStaff: true, …}
__proto__: Object
path: "search"
service: {events: Array(4), path: "search", connection: Socket, method: "emit", timeout: 130000, …}
type: "before"
toJSON: ƒ value()
__proto__: Object
message: "Timeout of 130000ms exceeded calling create on search"
name: "Timeout"
type: "FeathersError"
```