### PR TITLE
New 'collection' filter to text reuse clusters

### DIFF
--- a/src/components/modules/textReuse/ClustersSearchPanel.vue
+++ b/src/components/modules/textReuse/ClustersSearchPanel.vue
@@ -4,7 +4,7 @@
       <search-pills :filters="filters"
         :includedFilterTypes="supportedFilterTypes"
         @changed="handleFiltersChanged"
-        :index="'tr_clusters'"
+        :index="'tr_passages'"
         :enableAddFilter="true" />
     </div>
 

--- a/src/logic/filters.js
+++ b/src/logic/filters.js
@@ -174,7 +174,8 @@ export const SupportedFiltersByContext = Object.freeze({
     'textReuseClusterLexicalOverlap',
     'textReuseClusterDayDelta',
     'daterange',
-    'newspaper'
+    'newspaper',
+    'collection'
   ],
   entities: [
     'string',

--- a/src/pages/TextReuseClusters.vue
+++ b/src/pages/TextReuseClusters.vue
@@ -56,7 +56,7 @@ import ClusterDetailsPanel from '@/components/modules/textReuse/ClusterDetailsPa
 
 import List from '@/components/modules/lists/List';
 import { textReuseClusters, filtersItems } from '@/services';
-import { toCanonicalFilter, toSerializedFilters } from '@/logic/filters';
+import { toCanonicalFilter, toSerializedFilters, SupportedFiltersByContext } from '@/logic/filters';
 import { CommonQueryParameters } from '@/router/util';
 import { mapFilters } from '@/logic/queryParams'
 
@@ -70,13 +70,7 @@ const isLastItem = (index, total) => total - 1 === index
 
 const serializeFilters = filters => protobuf.searchQuery.serialize({ filters: filters.map(toCanonicalFilter) })
 
-const SupportedFilterTypes = [
-  'daterange',
-  'newspaper',
-  'textReuseClusterSize',
-  'textReuseClusterLexicalOverlap',
-  'textReuseClusterDayDelta'
-]
+const SupportedFilterTypes = SupportedFiltersByContext.textReuse
 const supportedFiltersFilter = filter => SupportedFilterTypes.includes(filter.type)
 
 const QueryParameters = Object.freeze({


### PR DESCRIPTION
Using `tr_passages` index for facets because collections filed does not exist on `tr_clusters`.