### PR TITLE
Hotfix/remove bogus contents

### DIFF
--- a/src/components/CollectionDetailPage.vue
+++ b/src/components/CollectionDetailPage.vue
@@ -373,6 +373,7 @@ export default {
         this.tab = tabIdx !== -1 ? this.tabs[tabIdx] : this.tabs[0];
         // load collection
         if (params.collection_uid) {
+          this.fetching = true;
           this.collection = await collectionsService
             .get(this.collectionUid)
             .then((collection) => new Collection(collection));

--- a/src/components/modules/CollectionList.vue
+++ b/src/components/modules/CollectionList.vue
@@ -50,7 +50,6 @@
               'mb-4': index === collections.length - 1
             }"
             v-bind:key="index">
-            <span class="selection-indicator pr-1"/>
             <div
               class="w-100 m-0 px-3 py-2 details-panel"
               v-on:click="select(collection, $event)"
@@ -64,7 +63,7 @@
               <div>
                 <div class="description small pb-1">
                   <span  v-if="collection.description">{{collection.description}} – </span>
-                  <span v-if="collection.countItems">{{collection.countItems}} {{$t('items')}} – </span>
+                  <!-- <span v-if="collection.countItems">{{collection.countItems}} {{$t('items')}} – </span> -->
                   <span v-if="collection.creationDate">
                     {{$t('created')}} {{ $d(collection.creationDate, 'compact')}}
                   </span>
@@ -274,7 +273,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import "impresso-theme/src/scss/bootpresso.scss";
+// @import "impresso-theme/src/scss/bootpresso.scss";
 // @import "bootstrap/scss/_variables.scss";
 
 .collection-list {
@@ -283,15 +282,17 @@ export default {
   }
   .details-panel:hover {
     cursor: pointer;
-    background-color: $clr-bg-secondary;
+    // background-color: $clr-bg-secondary;
   }
 
   .active {
     .selection-indicator {
-      background-color: $clr-accent-secondary;
+      // background-color: $clr-accent-secondary;
     }
     .details-panel {
-      background-color: $clr-bg-secondary;
+      box-shadow: inset 0.15em 0 #343a40;
+background-color: #f2f2f2;
+      // background-color: $clr-bg-secondary;
     }
   }
 }

--- a/src/components/modules/textReuse/ClusterDetailsPanel.vue
+++ b/src/components/modules/textReuse/ClusterDetailsPanel.vue
@@ -2,7 +2,7 @@
   <div class="cluster-details-panel">
     <!-- header -->
     <div class="d-flex">
-      <h2 class="flex-grow-1">
+      <h2 class="flex-grow-1 sans">
         <span>#{{ clusterId }}</span>
       </h2>
 
@@ -85,7 +85,9 @@ export default {
   @import "impresso-theme/src/scss/variables.sass";
 
   .cluster-details-panel {
-
+    h2{
+      font-size: inherit;
+    }
     &.selected, &:hover{
       h2 span,
       .text-sample > span{

--- a/src/components/modules/textReuse/PassageDetailsPanel.vue
+++ b/src/components/modules/textReuse/PassageDetailsPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-flex flex-column">
+  <div class="d-flex flex-column passage-details-panel">
     <!-- image and text -->
     <div class="d-flex flex-row">
       <div class="image flex-shrink-1 d-flex">
@@ -31,7 +31,6 @@
   <!-- text -->
   <div>
     {{passage.content}}
-    {{passage}}
   </div>
       </div>
     </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,7 +7,6 @@ import FaqPage from '../components/FaqPage';
 import TermsOfUsePage from '../components/TermsOfUsePage';
 import IssuePage from '../components/IssuePage';
 import UserLoginPage from '../components/UserLoginPage';
-import CollectionDetailPage from '../components/CollectionDetailPage';
 import TestPage from '../components/TestPage';
 import NewspapersExplorerPage from '../components/NewspapersExplorerPage';
 import NewspapersDetailPage from '../components/NewspapersDetailPage';
@@ -147,7 +146,7 @@ const router = new Router({
       component: () => import(/* webpackChunkName: "collections" */ '../pages/Collections.vue'),
       children: [{
         path: '',
-        component: CollectionDetailPage,
+        component: () => import(/* webpackChunkName: "collections" */ '../components/CollectionDetailPage.vue'),
         name: 'collections',
         meta: {
           requiresAuth: true,
@@ -156,7 +155,7 @@ const router = new Router({
       },
       {
         path: ':collection_uid',
-        component: CollectionDetailPage,
+        component: () => import(/* webpackChunkName: "collections" */ '../components/CollectionDetailPage.vue'),
         name: 'collection',
         meta: {
           requiresAuth: true,


### PR DESCRIPTION
- Fixed style bug (wrongly loading an external css file) on text reuse clusters
- removed display of `countItems` for the list of user collections as the number is not reliable for the moment
- remove bogus JSON content