### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7835,7 +7835,7 @@
     },
     "node_modules/impresso-ui-components": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/impresso/impresso-ui-components.git#e634c0f500a5889b4eba1b367154e0d0de113912",
+      "resolved": "git+ssh://git@github.com/impresso/impresso-ui-components.git#d7b5f5c01ae248c79a7d72ee52e6025d1b131480",
       "dependencies": {
         "@vuelidate/core": "^2.0.3",
         "@vuelidate/validators": "^2.0.4",


### PR DESCRIPTION
fix #1626 the updated version of BModel has the missing slot where the facets were displayed