### PR TITLE
Add ContentItemIdLabel component and integrate in heading

### DIFF
--- a/src/components/ContentItemIdLabel.stories.ts
+++ b/src/components/ContentItemIdLabel.stories.ts
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ContentItemIdLabel from '@/components/ContentItemIdLabel.vue'
+import type { ContentItemIdLabelProps } from '@/components/ContentItemIdLabel.vue'
+
+const meta: Meta<typeof ContentItemIdLabel> = {
+  title: 'Components/ContentItemIdLabel',
+  component: ContentItemIdLabel,
+  tags: ['autodocs'],
+  render: args => {
+    return {
+      setup() {
+        return { args }
+      },
+      components: { ContentItemIdLabel },
+      template: `
+        <div class="bg-light d-flex align-items-center p-4" style="height: 200px;width: 100%;">
+          <ContentItemIdLabel v-bind="args">
+          </ContentItemIdLabel>
+        </div>
+      `
+    }
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    item: {
+      id: 'GDU-1900-01-01-a-i0234',
+      type: 'ar',
+      dataProvider: 'Impresso',
+      publicationDate: '2024-01-01',
+      title: 'Sample Article',
+      nbPages: 10,
+      pages: [],
+      transcriptLength: 0,
+      access: {
+        dataDomain: 'prt',
+        copyright: 'in_cpy',
+        accessBitmaps: {
+          explore: 'AAAAAAAAAAI=',
+          getTranscript: 'AAAAgAAAAAA=',
+          getImages: 'AAAAgAAAAAA='
+        }
+      }
+    }
+  } as ContentItemIdLabelProps
+}

--- a/src/components/ContentItemIdLabel.vue
+++ b/src/components/ContentItemIdLabel.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="rounded border px-2 small text-muted d-inline-block">
+    {{ props.item.id }}
+    <InfoButton
+      style="margin-top: -2px"
+      :default-content="$t('id_description')"
+      :name="$t('id_text')"
+    ></InfoButton>
+  </div>
+</template>
+<script lang="ts" setup>
+import type { ContentItem } from '@/models/generated/schemas/contentItem.d.ts'
+import InfoButton from './base/InfoButton.vue'
+
+export interface ContentItemIdLabelProps {
+  item: ContentItem
+}
+
+const props = defineProps<ContentItemIdLabelProps>()
+</script>
+<i18n lang="json">
+{
+  "en": {
+    "id_text": "Content Item ID",
+    "id_description": "The Content Item ID is a unique identifier assigned to each content item in the Impresso system. It is used to reference and access specific content items within the database."
+  }
+}
+</i18n>

--- a/src/components/IssueViewerPageHeading.vue
+++ b/src/components/IssueViewerPageHeading.vue
@@ -51,6 +51,7 @@
               {{ $t('buckets.copyright.' + article.copyright) }}{{ ' ' }}</span
             >
             <DataProviderLabel v-if="dataProvider" class="d-inline-block" :item="dataProvider" />
+            <ContentItemIdLabel v-if="contentItem" :item="contentItem" class="ml-3" />
             <ContentItemAccess v-if="contentItem" :item="contentItem" class="ml-3" />
           </div>
           <div class="ml-auto" style="min-width: 200px">
@@ -76,6 +77,7 @@ import MediaSourceLabel from '@/components/modules/lists/MediaSourceLabel.vue'
 import { computed } from 'vue'
 import DataProviderLabel from './modules/lists/DataProviderLabel.vue'
 import ContentItemAccess from './ContentItemAccess.vue'
+import ContentItemIdLabel from './ContentItemIdLabel.vue'
 
 export interface IssueViewerPageHeadingProps {
   issue?: Issue


### PR DESCRIPTION
Introduces the ContentItemIdLabel component to display content item IDs with an info button and i18n support. Adds Storybook stories for the new component and integrates it into IssueViewerPageHeading.vue to show the content item ID alongside other metadata.