### PR TITLE
Add legend and power scale options to sources overview

### DIFF
--- a/src/components/sourcesOverview/SourceOverviewLegend.vue
+++ b/src/components/sourcesOverview/SourceOverviewLegend.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="SourceOverviewLegend">
+    <h2 class="small-caps m-0">{{ $t('legend') }}</h2>
+    <p class="very-small text-muted font-style-italic m-0">
+      {{ $t('colorGradient') }}
+    </p>
+    <div class="d-flex align-items-end gap-2 justify-content-center mb-2">
+      <div class="position-relative w-100">
+        <div class="position-absolute top-0 left-0 pr-2 very-small">
+          {{ $n(dataValuesExtent.min) }}
+        </div>
+        <div
+          class="legend-gradient"
+          :style="{
+            width: '100%',
+            height: '20px',
+            marginTop: '20px',
+            background: `linear-gradient(to right, ${colorScale(dataValuesExtent.min)}, ${colorScale(dataValuesExtent.max)})`
+          }"
+        ></div>
+        <div class="position-absolute top-0 right-0 pl-2 very-small text-right">
+          {{ $n(dataValuesExtent.max) }}
+        </div>
+      </div>
+      <InfoButton :name="$t('colorGradient')" :default-content="$t('colorGradientExplanation')" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { interpolateYlGn, scaleSequential } from 'd3'
+import { computed } from 'vue'
+import InfoButton from '../base/InfoButton.vue'
+
+export interface SourceOverviewLegendProps {
+  dataValues?: Array<{
+    value: number
+    dataValues?: Array<{ value: number }>
+  }>
+  normalizeLocally?: boolean
+}
+
+const props = withDefaults(defineProps<SourceOverviewLegendProps>(), {
+  normalizeLocally: false
+})
+
+const dataValuesExtent = computed<{ min: number; max: number }>(() => {
+  let min = Infinity
+  let max = -Infinity
+  props.dataValues!.forEach(dv => {
+    if (Array.isArray(dv.dataValues) && dv.dataValues.length > 0) {
+      dv.dataValues.forEach(nestedDv => {
+        if (nestedDv.value < min) min = nestedDv.value
+        if (nestedDv.value > max) max = nestedDv.value
+      })
+    } else {
+      if (dv.value < min) min = dv.value
+      if (dv.value > max) max = dv.value
+    }
+  })
+  return { min, max }
+})
+
+const colorScale = computed(() => {
+  return scaleSequential(t => interpolateYlGn(0.5 + t * 0.5)).domain([
+    0,
+    dataValuesExtent.value.max
+  ])
+})
+</script>
+<i18n lang="json">
+{
+  "en": {
+    "colorGradient": "Color Gradient",
+    "colorGradientExplanation": "The color gradient represents the number of content items over time across all sources."
+  }
+}
+</i18n>

--- a/src/components/sourcesOverview/SourcesOverviewDateValueItem.vue
+++ b/src/components/sourcesOverview/SourcesOverviewDateValueItem.vue
@@ -6,7 +6,13 @@
         height: height + 'px'
       }"
     >
-      <div class="label font-weight-bold small">{{ dataValue.label }}</div>
+      <div
+        class="label font-weight-bold small position-relative"
+        :class="{ 'reduced-label': reducedLabel }"
+        :title="dataValue.label"
+      >
+        {{ dataValue.label }}
+      </div>
       <div v-if="dataValue.dateRange" class="date-range text-no-wrap very-small">
         {{ $d(dataValue.dateRange[0], 'month') }}
       </div>
@@ -74,9 +80,11 @@ export interface DataValue {
 
 export interface SourcesOverviewDateValueItemProps {
   dataValue: DataValue
+  reducedLabel?: boolean
   width?: number
   height?: number
   barHeight?: number
+  minBarHeight?: number
   exponent?: number
   normalizeLocally?: boolean
   minValue?: number
@@ -85,9 +93,11 @@ export interface SourcesOverviewDateValueItemProps {
 }
 
 const props = withDefaults(defineProps<SourcesOverviewDateValueItemProps>(), {
+  reducedLabel: false,
   width: 100,
   height: 30,
   barHeight: 1,
+  minBarHeight: 4,
   exponent: 1,
   normalizeLocally: false,
   backgroundColor: 'purple'
@@ -127,7 +137,7 @@ const yScale = computed(() => {
   return scalePow()
     .exponent(props.exponent)
     .domain([minValue.value, maxValue.value])
-    .range([2, props.height])
+    .range([props.minBarHeight, props.height])
     .clamp(true)
 })
 const onClick = (event: MouseEvent) => {
@@ -135,3 +145,17 @@ const onClick = (event: MouseEvent) => {
   console.log('Clicked on', props.dataValue)
 }
 </script>
+<style>
+.SourcesOverviewDateValueItem .label {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.SourcesOverviewDateValueItem .reduced-label {
+  max-width: 50px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/sourcesOverview/SourcesOverviewTimeline.vue
+++ b/src/components/sourcesOverview/SourcesOverviewTimeline.vue
@@ -166,13 +166,28 @@
               'px)'
           }"
         >
+          <div
+            class="position-absolute very-small rounded-sm px-2 text-muted"
+            v-if="props.minimumVerticalGap >= 40"
+            style="
+              white-space: nowrap;
+              right: 8px;
+              top: 4px;
+              background-color: var(--clr-grey-100-rgba-10);
+            "
+          >
+            {{ idx }} of {{ dataValues.length }}
+          </div>
           <SourcesOverviewDateValueItem
             :normalizeLocally="props.normalizeLocally"
             :dataValue="dataValue"
             :min-value="dataValuesExtent.min"
             :max-value="dataValuesExtent.max"
+            :minBarHeight="props.minimumVerticalHeight"
             :height="props.minimumVerticalGap"
+            :reducedLabel="xScale(dataValue.dateRange[0]) < 200"
             :width="xScale(dataValue.dateRange[1]) - xScale(dataValue.dateRange[0])"
+            :exponent="props.scaleExponent"
           />
         </div>
       </div>
@@ -196,22 +211,26 @@ export interface Props {
   dataValues?: DataValue[]
   minimumGap?: number
   minimumVerticalGap?: number
+  minimumVerticalHeight?: number
   normalizeLocally?: boolean
   maxTooltipHeight?: number
   timeResolution?: 'year' | 'month' | 'day'
   addExtraHorizontalSpace?: boolean
   fitToContainerWidth?: boolean
+  scaleExponent?: number
 }
 
 const props = withDefaults(defineProps<Props>(), {
   dataValues: () => [],
   minimumGap: 8,
   minimumVerticalGap: 20,
+  minimumVerticalHeight: 4,
   normalizeLocally: false,
   maxTooltipHeight: 200,
   timeResolution: 'year',
   addExtraHorizontalSpace: true,
-  fitToContainerWidth: true
+  fitToContainerWidth: true,
+  scaleExponent: 2
 })
 
 const emit = defineEmits<{

--- a/src/pages/SourcesOverviewPage.vue
+++ b/src/pages/SourcesOverviewPage.vue
@@ -15,6 +15,7 @@ import { watch } from 'vue'
 import { computed, onMounted, ref } from 'vue'
 import type { DataValue } from '@/components/sourcesOverview/SourcesOverviewDateValueItem.vue'
 import InfoButton from '@/components/base/InfoButton.vue'
+import SourceOverviewLegend from '@/components/sourcesOverview/SourceOverviewLegend.vue'
 interface Props {
   filtersWithItems?: Array<any>
   filters?: Array<any>
@@ -75,6 +76,8 @@ const normalize = ref(false)
 const fitToContainerWidth = ref(false)
 const minimumGap = ref<number>(10)
 const minimumVerticalGap = ref<number>(50)
+const minimumVerticalHeight = ref<number>(4)
+const withPowerScale = ref(true)
 
 watch(
   () => props.filters,
@@ -178,7 +181,7 @@ onMounted(() => {
 <template>
   <i-layout class="SearchOverviewPage">
     <SearchSidebar
-      width="300px"
+      width="350px"
       :filters="allowedFiltersWithItems"
       :facets="facets"
       contextTag="search"
@@ -200,6 +203,14 @@ onMounted(() => {
           :label="$t('pageLabel' + (isLoading ? '-loading' : ''))"
           :title="$t('pageTitle' + (isLoading ? '-loading' : ''))"
         >
+          <template #actions>
+            <!-- Future action buttons can be added here -->
+            <SourceOverviewLegend
+              style="width: 150px"
+              :dataValues="dataValues"
+              :normalizeLocally="normalize"
+            />
+          </template>
           <template #summaryActions>
             <b-dropdown size="sm" variant="outline-secondary" right containsForm initialIsOpen>
               <template #button-content> {{ $t('visualisationSettings') }}</template>
@@ -227,7 +238,8 @@ onMounted(() => {
                   >
                   </InfoButton>
                 </div>
-                <div class="mx-3 my-2">
+
+                <div class="mx-3 my-2 pb-3 border-bottom">
                   <span class="text-muted small">{{ $t('minimumGap') }}</span>
                   <b-form-input
                     type="number"
@@ -235,7 +247,7 @@ onMounted(() => {
                     min="10"
                     step="1"
                     :disabled="fitToContainerWidth"
-                    class="rounded-sm"
+                    class="rounded-sm form-control-sm"
                   ></b-form-input>
                 </div>
                 <div class="mx-3 my-2">
@@ -245,8 +257,29 @@ onMounted(() => {
                     v-model.number="minimumVerticalGap"
                     min="15"
                     step="1"
-                    class="rounded-sm"
+                    class="rounded-sm form-control-sm"
                   ></b-form-input>
+                </div>
+                <div class="mx-3 my-2">
+                  <span class="text-muted small">{{ $t('minimumVerticalHeight') }}</span>
+                  <b-form-input
+                    type="number"
+                    v-model.number="minimumVerticalHeight"
+                    :min="1"
+                    :max="minimumVerticalGap"
+                    step="1"
+                    class="rounded-sm form-control-sm"
+                  ></b-form-input>
+                </div>
+                <div class="d-flex align-items-center justify-content-between mx-3 py-2 gap-2">
+                  <b-form-checkbox v-model="withPowerScale" switch>
+                    <span class="no-small-caps">{{ $t('withPowerScale') }}</span>
+                  </b-form-checkbox>
+                  <InfoButton
+                    :name="$t('withPowerScaleInfoTitle')"
+                    :defaultContent="$t('withPowerScaleInfoDescription')"
+                  >
+                  </InfoButton>
                 </div>
               </section>
             </b-dropdown>
@@ -283,6 +316,8 @@ onMounted(() => {
         :dataValues="dataValues"
         :minimumGap="minimumGap"
         :minimumVerticalGap="minimumVerticalGap"
+        :minimumVerticalHeight="minimumVerticalHeight"
+        :scaleExponent="withPowerScale ? 4 : 1"
       />
     </i-layout-section>
   </i-layout>
@@ -304,7 +339,11 @@ onMounted(() => {
     "fitToContainerWidthInfoTitle": "Fit to Container Width",
     "fitToContainerWidthInfoDescription": "When enabled, the timeline will adjust its width to fit the container, providing an optimal viewing experience across different screen sizes.",
     "minimumVerticalGap": "Vertical bar height (px)",
-    "minimumGap": "Horizontal bar width (px)"
+    "minimumGap": "Horizontal bar width (px)",
+    "minimumVerticalHeight": "Minimum height for lower values (px)",
+    "withPowerScale": "With Power Scale",
+    "withPowerScaleInfoTitle": "With Power Scale",
+    "withPowerScaleInfoDescription": "When enabled, the vertical scaling of the bars will use a power scale, enhancing the visibility of sources with lower content volumes."
   }
 }
 </i18n>


### PR DESCRIPTION
Introduces a SourceOverviewLegend component and adds UI controls for minimum vertical bar height and power scale toggling in SourcesOverviewPage. Updates timeline and date value item components to support these new props, improving visualization flexibility and clarity.